### PR TITLE
fix a MissingRequiredParameter exception when job template is cmaf

### DIFF
--- a/source/encode/index.js
+++ b/source/encode/index.js
@@ -120,7 +120,8 @@ exports.handler = async (event) => {
           "FragmentLength": 3,
           "Destination": outputPath + '/cmaf/',
         }
-      }
+      },
+      "Outputs": []
     };
 
     let mss = {


### PR DESCRIPTION
Add missing outputs property which causes a fatal  


