### PR TITLE
normalize key format in order to support keys passed by metadata per …

### DIFF
--- a/source/input-validate/index.js
+++ b/source/input-validate/index.js
@@ -72,26 +72,26 @@ exports.handler = async (event) => {
         console.log('Validating Metadata file::');
         let key= decodeURIComponent(event.Records[0].s3.object.key.replace(/\+/g, " "));
         data.srcMetadataFile = key;
-    		//download json metadata file from s3::
-    		params = {
-    			Bucket: data.srcBucket,
-    			Key: key
-    		};
-    		let metadata = await s3.getObject(params).promise();
-    		let metadataFile = JSON.parse(metadata.Body);
+        //download json metadata file from s3::
+        params = {
+          Bucket: data.srcBucket,
+          Key: key
+        };
+        let metadata = await s3.getObject(params).promise();
+        let metadataFile = JSON.parse(metadata.Body);
 
         //Check metadata for srcVideo::
         if (!metadataFile.srcVideo) throw new Error('srcVideo is not defined in metadata::',metadataFile);
 
         Object.keys(metadataFile).forEach((key) => {
           let normalizedKey = key.charAt(0).toLowerCase() + key.substr(1);
-    			data[normalizedKey] = metadataFile[key];
-    		});
-    		//check source file is ccessible in s3
-    		params = {
-    			Bucket: data.srcBucket,
-    			Key: data.srcVideo
-    		};
+          data[normalizedKey] = metadataFile[key];
+        });
+        //check source file is ccessible in s3
+        params = {
+          Bucket: data.srcBucket,
+          Key: data.srcVideo
+        };
     		await s3.headObject(params).promise();
         break;
 

--- a/source/input-validate/index.js
+++ b/source/input-validate/index.js
@@ -84,7 +84,8 @@ exports.handler = async (event) => {
         if (!metadataFile.srcVideo) throw new Error('srcVideo is not defined in metadata::',metadataFile);
 
         Object.keys(metadataFile).forEach((key) => {
-    			data[key] = metadataFile[key];
+          let normalizedKey = key.charAt(0).toLowerCase() + key.substr(1);
+    			data[normalizedKey] = metadataFile[key];
     		});
     		//check source file is ccessible in s3
     		params = {


### PR DESCRIPTION
Per documentation on the `README.md` and https://docs.aws.amazon.com/solutions/latest/video-on-demand/appendix-e.html metadata overrides in input-validate's `index.js` with `cloudFront: process.env.CloudFront,`

```json
{
    "srcVideo": "string",
    "ArchiveSource": true,
    "FrameCapture": false,
    "Source":"string",
    "destination":"string",
    "CloudFront":"string",
    "MediaConvert_Template_2160p":"string",
    "MediaConvert_Template_1080p":"string",
    "MediaConvert_Template_720p":"string",
    "JobTemplate":"custom-job-template"
}
```

These keys are properly normalized for environment vars provided by `process.env` but not for metadata overrides. It looks like it was sort of discovered with the random camel case for `srcVideo` in the documentation. Passing `JobTemplate` and others, currently adds new keys and are missed  later on, for example, when `event.jobTemplate` is called with in encode. It doesn't fail, it just uses the default. You can get around this by passing `jobTemplate`, but is going to make things confusing across all the documentation. 