### PR TITLE
Do not randomly change the data format that is published to SNS

### DIFF
--- a/source/error-handler/index.js
+++ b/source/error-handler/index.js
@@ -68,11 +68,16 @@ exports.handler = async (event) => {
 
 		//Send SNS notification
 		let msg = {
-			Message: 'Please see the AWS console for detail :' + url + os.EOL + JSON.stringify(event, null, 2),
+			workflowStatus: 'error',
+			guid: event.guid,
+			srcVideo: event.srcVideo
+		};
+		let params = {
+			Message: JSON.stringify(msg, null, 2),
 			Subject: ' workflow error: ' + guid,
 			TargetArn: process.env.SnsTopic
 		};
-		await sns.publish(msg).promise();
+		await sns.publish(params).promise();
 	} catch (err) {
 		console.log(err);
 		throw err;

--- a/source/error-handler/index.js
+++ b/source/error-handler/index.js
@@ -69,15 +69,14 @@ exports.handler = async (event) => {
 		//Send SNS notification
 		let msg = {
 			workflowStatus: 'error',
-			guid: event.guid,
-			srcVideo: event.srcVideo
+			guid: guid
 		};
-		let params = {
+		let snsParams = {
 			Message: JSON.stringify(msg, null, 2),
 			Subject: ' workflow error: ' + guid,
 			TargetArn: process.env.SnsTopic
 		};
-		await sns.publish(params).promise();
+		await sns.publish(snsParams).promise();
 	} catch (err) {
 		console.log(err);
 		throw err;


### PR DESCRIPTION
If someone is using this solution, the first change they may make is adding subscriptions to SNS in order to manage states like `Ingested`, `Completed`, etc. 

The data structure usually returned from `sns-publish` is as follows
https://github.com/awslabs/video-on-demand-on-aws/blob/master/source/sns-notification/index.js#L56

In the `error-handler` function however, the data structure changes, which is going to fail when trying a subscriber tries to parse the notification, like a webhook. Ideally the only place this should be called is in `sns-notification` function, but let's at least make the data structure compatible for now. 
