### PR TITLE
Add QVBR Portrait Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ The workflow configuration is set at deployment and is defined as environment va
 * **MediaConvert_Template_2160p:**	The name of the UHD template in MediaConvert
 * **MediaConvert_Template_1080p:**	The name of the HD template in MediaConvert
 * **MediaConvert_Template_720p:**	The name of the SD template in MediaConvert
+* **MediaConvert_Template_2160p_Portrait:**  The name of the UHD portrait template in MediaConvert
+* **MediaConvert_Template_1080p_Portrait:**  The name of the HD portrait template in MediaConvert
+* **MediaConvert_Template_720p_Portrait:** The name of the SD portrait template in MediaConvert
 * **Source:**	The name of the Source S3 bucket.
 * **WorkflowName:**	Used to tag all of the MediaConvert Encoding Jobs.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ The only required field for the metadata file is the srcVideo and the workflow w
     "MediaConvert_Template_2160p":"string",
     "MediaConvert_Template_1080p":"string",
     "MediaConvert_Template_720p":"string",
+    "MediaConvert_Template_2160p_Portrait":"string",
+    "MediaConvert_Template_1080p_Portrait":"string",
+    "MediaConvert_Template_720p_Portrait":"string",
     "JobTemplate":"custom-job-template"
 }
 ```
@@ -103,6 +106,12 @@ At launch the Solution creates 3 MediaConvert job templates which are used as th
 **MediaConvert_Template_1080p::** 2 mp4 outputs AVC 2160p through 720p, 8 HLS outputs AVC 1080p through 270p and 8 DASH outputs AVC 1080p through 270p
 
 **MediaConvert_Template_720p::** 1 mp4 720p AVC output, 7 HLS outputs AVC 720p through 270p and 7 DASH outputs AVC 720p through 270p
+
+**MediaConvert_Template_2160p_Portrait::** NOTE: portrait conversion only works when QVBR is enabled. 2 mp4 outputs AVC 2160p through 720p, 8 HLS outputs AVC 1080p through 270p and 8 DASH outputs AVC 1080p through 270p
+
+**MediaConvert_Template_1080p_Portrait::** NOTE: portrait conversion only works when QVBR is enabled. 2 mp4 outputs AVC 2160p through 720p, 8 HLS outputs AVC 1080p through 270p and 8 DASH outputs AVC 1080p through 270p
+
+**MediaConvert_Template_720p_Portrait::** NOTE: portrait conversion only works when QVBR is enabled. 1 mp4 720p AVC output, 7 HLS outputs AVC 720p through 270p and 7 DASH outputs AVC 720p through 270p
 
 By default, the profiler step in the process step function will check the source video height and set the parameter “JobTemplate” to one of the available templates. This variable is then passed to the encoding step which submits a job to Elemental MediaConvert. To customizing the encoding templates used by the solution you can either replace the existing templates or you can use the source metadata version of the workflow and define the JobTemplate as part of the source metadata file.
 

--- a/deployment/video-on-demand-on-aws.yaml
+++ b/deployment/video-on-demand-on-aws.yaml
@@ -650,7 +650,7 @@ Resources:
       Description: Creates a MediaConvert encode job
       Handler: index.handler
       Layers:
-        - !GetAtt LatestAWSSDK.Arn
+        - !Ref LatestAWSSDK
       Role: !GetAtt WorkflowRole.Arn
       Code:
         S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]

--- a/deployment/video-on-demand-on-aws.yaml
+++ b/deployment/video-on-demand-on-aws.yaml
@@ -553,6 +553,18 @@ Resources:
 # Workflow Lambda Functions
 
 # workflow triggers
+  LatestAWSSDK:
+    Type: "AWS::Lambda::LayerVersion"
+    Properties:
+      CompatibleRuntimes: 
+        - nodejs8.10
+      Content: 
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
+        S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "nodejs.zip"]]
+      Description: Latest AWS SDK Package
+      LayerName: latest-aws-sdk
+      LicenseInfo: MIT
+
   InputValidate:
     Type: AWS::Lambda::Function
     Properties:
@@ -637,6 +649,8 @@ Resources:
       FunctionName: !Sub ${AWS::StackName}-encode
       Description: Creates a MediaConvert encode job
       Handler: index.handler
+      Layers:
+        - !GetAtt LatestAWSSDK.Arn
       Role: !GetAtt WorkflowRole.Arn
       Code:
         S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]

--- a/deployment/video-on-demand-on-aws.yaml
+++ b/deployment/video-on-demand-on-aws.yaml
@@ -576,6 +576,9 @@ Resources:
           MediaConvert_Template_2160p: !Join ["", [ Ref: "AWS::StackName", !If ["EnableQvbr", "_Ott_2160p_Avc_Aac_16x9_qvbr", "_Ott_2160p_Avc_Aac_16x9"]]]
           MediaConvert_Template_1080p: !Join ["", [ Ref: "AWS::StackName", !If ["EnableQvbr", "_Ott_1080p_Avc_Aac_16x9_qvbr", "_Ott_1080p_Avc_Aac_16x9"]]]
           MediaConvert_Template_720p: !Join ["", [ Ref: "AWS::StackName", !If ["EnableQvbr", "_Ott_720p_Avc_Aac_16x9_qvbr", "_Ott_720p_Avc_Aac_16x9"]]]
+          MediaConvert_Template_2160p_Portrait: !Join ["", [ Ref: "AWS::StackName", !If ["EnableQvbr", "_Ott_2160p_Avc_Aac_9x16_qvbr", "_Ott_2160p_Avc_Aac_16x9"]]]
+          MediaConvert_Template_1080p_Portrait: !Join ["", [ Ref: "AWS::StackName", !If ["EnableQvbr", "_Ott_1080p_Avc_Aac_9x16_qvbr", "_Ott_1080p_Avc_Aac_16x9"]]]
+          MediaConvert_Template_720p_Portrait: !Join ["", [ Ref: "AWS::StackName", !If ["EnableQvbr", "_Ott_720p_Avc_Aac_9x16_qvbr", "_Ott_720p_Avc_Aac_16x9"]]]
           CloudFront: !GetAtt CloudFront.DomainName
 
   Mediainfo:

--- a/source/custom-resource/lib/mediaconvert/index.js
+++ b/source/custom-resource/lib/mediaconvert/index.js
@@ -26,6 +26,14 @@ const qvbrPresets = [{
         file: './lib/mediaconvert/presets/_Mp4_Avc_Aac_16x9_1920x1080p_24Hz_6Mbps_qvbr.json'
     },
     {
+        name: '_Mp4_Avc_Aac_9x16_720x1280p_24Hz_4.5Mbps_qvbr',
+        file: './lib/mediaconvert/presets/_Mp4_Avc_Aac_9x16_720x1280p_24Hz_4.5Mbps_qvbr.json'
+    },
+    {
+        name: '_Mp4_Avc_Aac_9x16_1080x1920p_24Hz_6Mbps_qvbr',
+        file: './lib/mediaconvert/presets/_Mp4_Avc_Aac_9x16_1080x1920p_24Hz_6Mbps_qvbr.json'
+    },
+    {
         name: '_Mp4_Hevc_Aac_16x9_3840x2160p_24Hz_20Mbps_qvbr',
         file: './lib/mediaconvert/presets/_Mp4_Hevc_Aac_16x9_3840x2160p_24Hz_20Mbps_qvbr.json'
     },
@@ -92,6 +100,70 @@ const qvbrPresets = [{
     {
         name: '_Ott_Hls_Ts_Avc_Aac_16x9_960x540p_30Hz_3.5Mbps_qvbr',
         file: './lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_16x9_960x540p_30Hz_3.5Mbps_qvbr.json'
+    },
+    {
+        name: '_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_6.5Mbps_qvbr',
+        file: './lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_6.5Mbps_qvbr.json'
+    },
+    {
+        name: '_Ott_Dash_Mp4_Avc_9x16_270x480p_15Hz_0.4Mbps_qvbr',
+        file: './lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_270x480p_15Hz_0.4Mbps_qvbr.json'
+    },
+    {
+        name: '_Ott_Dash_Mp4_Avc_9x16_1080x1920p_30Hz_8.5Mbps_qvbr',
+        file: './lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_1080x1920p_30Hz_8.5Mbps_qvbr.json'
+    },
+    {
+        name: '_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_0.6Mbps_qvbr',
+        file: './lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_0.6Mbps_qvbr.json'
+    },
+    {
+        name: '_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_3.5Mbps_qvbr',
+        file: './lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_3.5Mbps_qvbr.json'
+    },
+    {
+        name: '_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_1.2Mbps_qvbr',
+        file: './lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_1.2Mbps_qvbr.json'
+    },
+    {
+        name: '_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_5.0Mbps_qvbr',
+        file: './lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_5.0Mbps_qvbr.json'
+    },
+    {
+        name: '_Ott_Dash_Mp4_Avc_9x16_540x960p_30Hz_3.5Mbps_qvbr',
+        file: './lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_540x960p_30Hz_3.5Mbps_qvbr.json'
+    },
+    {
+        name: '_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_3.5Mbps_qvbr',
+        file: './lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_3.5Mbps_qvbr.json'
+    },
+    {
+        name: '_Ott_Hls_Ts_Avc_Aac_9x16_270x480p_15Hz_0.4Mbps_qvbr',
+        file: './lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_9x16_270x480p_15Hz_0.4Mbps_qvbr.json'
+    },
+    {
+        name: '_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_5.0Mbps_qvbr',
+        file: './lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_5.0Mbps_qvbr.json'
+    },
+    {
+        name: '_Ott_Hls_Ts_Avc_Aac_9x16_360x640p_30Hz_0.6Mbps_qvbr',
+        file: './lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_9x16_360x640p_30Hz_0.6Mbps_qvbr.json'
+    },
+    {
+        name: '_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_6.5Mbps_qvbr',
+        file: './lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_6.5Mbps_qvbr.json'
+    },
+    {
+        name: '_Ott_Hls_Ts_Avc_Aac_9x16_360x640p_30Hz_1.2Mbps_qvbr',
+        file: './lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_9x16_360x640p_30Hz_1.2Mbps_qvbr.json'
+    },
+    {
+        name: '_Ott_Hls_Ts_Avc_Aac_9x16_1080x1920p_30Hz_8.5Mbps_qvbr',
+        file: './lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_9x16_1080x1920p_30Hz_8.5Mbps_qvbr.json'
+    },
+    {
+        name: '_Ott_Hls_Ts_Avc_Aac_9x16_540x960p_30Hz_3.5Mbps_qvbr',
+        file: './lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_9x16_540x960p_30Hz_3.5Mbps_qvbr.json'
     }
 ];
 
@@ -111,6 +183,18 @@ const qvbrTemplates = [{
     {
         name: '_Ott_720p_Avc_Aac_16x9_qvbr',
         file: './lib/mediaconvert/templates/720p_avc_aac_16x9_qvbr.json'
+    },
+    {
+        name: '_Ott_2160p_Avc_Aac_9x16_qvbr',
+        file: './lib/mediaconvert/templates/2160p_avc_aac_9x16_qvbr.json'
+    },
+    {
+        name: '_Ott_1080p_Avc_Aac_9x16_qvbr',
+        file: './lib/mediaconvert/templates/1080p_avc_aac_9x16_qvbr.json'
+    },
+    {
+        name: '_Ott_720p_Avc_Aac_9x16_qvbr',
+        file: './lib/mediaconvert/templates/720p_avc_aac_9x16_qvbr.json'
     }
 ];
 

--- a/source/custom-resource/lib/mediaconvert/presets/_Mp4_Avc_Aac_9x16_1080x1920p_24Hz_6Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Mp4_Avc_Aac_9x16_1080x1920p_24Hz_6Mbps_qvbr.json
@@ -1,0 +1,99 @@
+{
+  "Description": "video on demand on aws",
+  "Category": "VOD",
+  "Name": "_Mp4_Avc_Aac_9x16_1080x1920p_24Hz_6Mbps_qvbr",
+  "Settings": {
+    "VideoDescription": {
+      "Width": 1080,
+      "ScalingBehavior": "DEFAULT",
+      "Height": 1920,
+      "VideoPreprocessors": {
+        "Deinterlacer": {
+          "Algorithm": "INTERPOLATE",
+          "Mode": "DEINTERLACE",
+          "Control": "NORMAL"
+        }
+      },
+      "TimecodeInsertion": "DISABLED",
+      "AntiAlias": "ENABLED",
+      "Sharpness": 50,
+      "CodecSettings": {
+        "Codec": "H_264",
+        "H264Settings": {
+          "InterlaceMode": "PROGRESSIVE",
+          "ParNumerator": 1,
+          "NumberReferenceFrames": 3,
+          "Syntax": "DEFAULT",
+          "Softness": 0,
+          "FramerateDenominator": 1001,
+          "GopClosedCadence": 1,
+          "HrdBufferInitialFillPercentage": 90,
+          "GopSize": 2,
+          "Slices": 1,
+          "GopBReference": "DISABLED",
+          "HrdBufferSize": 12000000,
+          "MaxBitrate": 6000000,
+          "SlowPal": "DISABLED",
+          "ParDenominator": 1,
+          "SpatialAdaptiveQuantization": "ENABLED",
+          "TemporalAdaptiveQuantization": "ENABLED",
+          "FlickerAdaptiveQuantization": "ENABLED",
+          "EntropyEncoding": "CABAC",
+          "FramerateControl": "SPECIFIED",
+          "RateControlMode": "QVBR",
+          "QvbrSettings": {
+            "QvbrQualityLevel": 8
+          },
+          "CodecProfile": "HIGH",
+          "Telecine": "NONE",
+          "FramerateNumerator": 24000,
+          "MinIInterval": 0,
+          "AdaptiveQuantization": "HIGH",
+          "CodecLevel": "LEVEL_4",
+          "FieldEncoding": "PAFF",
+          "SceneChangeDetect": "ENABLED",
+          "QualityTuningLevel": "SINGLE_PASS_HQ",
+          "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+          "UnregisteredSeiTimecode": "DISABLED",
+          "GopSizeUnits": "SECONDS",
+          "ParControl": "SPECIFIED",
+          "NumberBFramesBetweenReferenceFrames": 1,
+          "RepeatPps": "DISABLED"
+        }
+      },
+      "AfdSignaling": "NONE",
+      "DropFrameTimecode": "ENABLED",
+      "RespondToAfd": "NONE",
+      "ColorMetadata": "INSERT"
+    },
+    "AudioDescriptions": [
+      {
+        "AudioTypeControl": "FOLLOW_INPUT",
+        "AudioSourceName": "Audio Selector 1",
+        "CodecSettings": {
+          "Codec": "AAC",
+          "AacSettings": {
+            "AudioDescriptionBroadcasterMix": "NORMAL",
+            "Bitrate": 160000,
+            "RateControlMode": "CBR",
+            "CodecProfile": "LC",
+            "CodingMode": "CODING_MODE_2_0",
+            "RawFormat": "NONE",
+            "SampleRate": 48000,
+            "Specification": "MPEG4"
+          }
+        },
+        "LanguageCodeControl": "FOLLOW_INPUT",
+        "AudioType": 0
+      }
+    ],
+    "ContainerSettings": {
+      "Container": "MP4",
+      "Mp4Settings": {
+        "CslgAtom": "INCLUDE",
+        "FreeSpaceBox": "EXCLUDE",
+        "MoovPlacement": "PROGRESSIVE_DOWNLOAD"
+      }
+    }
+  }
+}

--- a/source/custom-resource/lib/mediaconvert/presets/_Mp4_Avc_Aac_9x16_1080x1920p_24Hz_6Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Mp4_Avc_Aac_9x16_1080x1920p_24Hz_6Mbps_qvbr.json
@@ -1,99 +1,92 @@
 {
-  "Description": "video on demand on aws",
-  "Category": "VOD",
-  "Name": "_Mp4_Avc_Aac_9x16_1080x1920p_24Hz_6Mbps_qvbr",
-  "Settings": {
-    "VideoDescription": {
-      "Width": 1080,
-      "ScalingBehavior": "DEFAULT",
-      "Height": 1920,
-      "VideoPreprocessors": {
-        "Deinterlacer": {
-          "Algorithm": "INTERPOLATE",
-          "Mode": "DEINTERLACE",
-          "Control": "NORMAL"
-        }
-      },
-      "TimecodeInsertion": "DISABLED",
-      "AntiAlias": "ENABLED",
-      "Sharpness": 50,
-      "CodecSettings": {
-        "Codec": "H_264",
-        "H264Settings": {
-          "InterlaceMode": "PROGRESSIVE",
-          "ParNumerator": 1,
-          "NumberReferenceFrames": 3,
-          "Syntax": "DEFAULT",
-          "Softness": 0,
-          "FramerateDenominator": 1001,
-          "GopClosedCadence": 1,
-          "HrdBufferInitialFillPercentage": 90,
-          "GopSize": 2,
-          "Slices": 1,
-          "GopBReference": "DISABLED",
-          "HrdBufferSize": 12000000,
-          "MaxBitrate": 6000000,
-          "SlowPal": "DISABLED",
-          "ParDenominator": 1,
-          "SpatialAdaptiveQuantization": "ENABLED",
-          "TemporalAdaptiveQuantization": "ENABLED",
-          "FlickerAdaptiveQuantization": "ENABLED",
-          "EntropyEncoding": "CABAC",
-          "FramerateControl": "SPECIFIED",
-          "RateControlMode": "QVBR",
-          "QvbrSettings": {
-            "QvbrQualityLevel": 8
-          },
-          "CodecProfile": "HIGH",
-          "Telecine": "NONE",
-          "FramerateNumerator": 24000,
-          "MinIInterval": 0,
-          "AdaptiveQuantization": "HIGH",
-          "CodecLevel": "LEVEL_4",
-          "FieldEncoding": "PAFF",
-          "SceneChangeDetect": "ENABLED",
-          "QualityTuningLevel": "SINGLE_PASS_HQ",
-          "FramerateConversionAlgorithm": "DUPLICATE_DROP",
-          "UnregisteredSeiTimecode": "DISABLED",
-          "GopSizeUnits": "SECONDS",
-          "ParControl": "SPECIFIED",
-          "NumberBFramesBetweenReferenceFrames": 1,
-          "RepeatPps": "DISABLED"
-        }
-      },
-      "AfdSignaling": "NONE",
-      "DropFrameTimecode": "ENABLED",
-      "RespondToAfd": "NONE",
-      "ColorMetadata": "INSERT"
-    },
-    "AudioDescriptions": [
-      {
-        "AudioTypeControl": "FOLLOW_INPUT",
-        "AudioSourceName": "Audio Selector 1",
-        "CodecSettings": {
-          "Codec": "AAC",
-          "AacSettings": {
-            "AudioDescriptionBroadcasterMix": "NORMAL",
-            "Bitrate": 160000,
-            "RateControlMode": "CBR",
-            "CodecProfile": "LC",
-            "CodingMode": "CODING_MODE_2_0",
-            "RawFormat": "NONE",
-            "SampleRate": 48000,
-            "Specification": "MPEG4"
-          }
+  "VideoDescription": {
+    "CodecSettings": {
+      "Codec": "H_264",
+      "H264Settings": {
+        "CodecProfile": "HIGH",
+        "SpatialAdaptiveQuantization": "ENABLED",
+        "TemporalAdaptiveQuantization": "ENABLED",
+        "Softness": 0,
+        "Syntax": "DEFAULT",
+        "FramerateNumerator": 24000,
+        "MinIInterval": 0,
+        "UnregisteredSeiTimecode": "DISABLED",
+        "FramerateControl": "SPECIFIED",
+        "NumberReferenceFrames": 3,
+        "FramerateDenominator": 1001,
+        "QvbrSettings": {
+          "QvbrQualityLevel": 8
         },
-        "LanguageCodeControl": "FOLLOW_INPUT",
-        "AudioType": 0
+        "MaxBitrate": 6000000,
+        "RateControlMode": "QVBR",
+        "GopBReference": "DISABLED",
+        "EntropyEncoding": "CABAC",
+        "GopSizeUnits": "SECONDS",
+        "FlickerAdaptiveQuantization": "ENABLED",
+        "Telecine": "NONE",
+        "ParDenominator": 1,
+        "AdaptiveQuantization": "HIGH",
+        "InterlaceMode": "PROGRESSIVE",
+        "QualityTuningLevel": "SINGLE_PASS_HQ",
+        "HrdBufferInitialFillPercentage": 90,
+        "RepeatPps": "DISABLED",
+        "FieldEncoding": "PAFF",
+        "SlowPal": "DISABLED",
+        "GopClosedCadence": 1,
+        "GopSize": 2.0,
+        "ParControl": "SPECIFIED",
+        "Slices": 1,
+        "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+        "ParNumerator": 1,
+        "SceneChangeDetect": "ENABLED",
+        "CodecLevel": "LEVEL_4",
+        "NumberBFramesBetweenReferenceFrames": 1,
+        "HrdBufferSize": 12000000
       }
-    ],
-    "ContainerSettings": {
-      "Container": "MP4",
-      "Mp4Settings": {
-        "CslgAtom": "INCLUDE",
-        "FreeSpaceBox": "EXCLUDE",
-        "MoovPlacement": "PROGRESSIVE_DOWNLOAD"
+    },
+    "DropFrameTimecode": "ENABLED",
+    "VideoPreprocessors": {
+      "Deinterlacer": {
+        "Control": "NORMAL",
+        "Mode": "DEINTERLACE",
+        "Algorithm": "INTERPOLATE"
       }
-    }
+    },
+    "RespondToAfd": "NONE",
+    "Sharpness": 50,
+    "AfdSignaling": "NONE",
+    "Height": 1920,
+    "Width": 1080,
+    "ScalingBehavior": "DEFAULT",
+    "ColorMetadata": "INSERT",
+    "AntiAlias": "ENABLED",
+    "TimecodeInsertion": "DISABLED"
+  },
+  "AudioDescriptions": [{
+    "CodecSettings": {
+      "Codec": "AAC",
+      "AacSettings": {
+        "CodecProfile": "LC",
+        "Specification": "MPEG4",
+        "RateControlMode": "CBR",
+        "AudioDescriptionBroadcasterMix": "NORMAL",
+        "SampleRate": 48000,
+        "Bitrate": 160000,
+        "CodingMode": "CODING_MODE_2_0",
+        "RawFormat": "NONE"
+      }
+    },
+    "AudioSourceName": "Audio Selector 1",
+    "AudioTypeControl": "FOLLOW_INPUT",
+    "LanguageCodeControl": "FOLLOW_INPUT",
+    "AudioType": 0
+  }],
+  "ContainerSettings": {
+    "Mp4Settings": {
+      "MoovPlacement": "PROGRESSIVE_DOWNLOAD",
+      "CslgAtom": "INCLUDE",
+      "FreeSpaceBox": "EXCLUDE"
+    },
+    "Container": "MP4"
   }
 }

--- a/source/custom-resource/lib/mediaconvert/presets/_Mp4_Avc_Aac_9x16_720x1280p_24Hz_4.5Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Mp4_Avc_Aac_9x16_720x1280p_24Hz_4.5Mbps_qvbr.json
@@ -1,0 +1,99 @@
+{
+  "Description": "video on demand on aws",
+  "Category": "VOD",
+  "Name": "_Mp4_Avc_Aac_9x16_720x1280p_24Hz_4.5Mbps_qvbr",
+  "Settings": {
+    "VideoDescription": {
+      "Width": 720,
+      "ScalingBehavior": "DEFAULT",
+      "Height": 1280,
+      "VideoPreprocessors": {
+        "Deinterlacer": {
+          "Algorithm": "INTERPOLATE",
+          "Mode": "DEINTERLACE",
+          "Control": "NORMAL"
+        }
+      },
+      "TimecodeInsertion": "DISABLED",
+      "AntiAlias": "ENABLED",
+      "Sharpness": 50,
+      "CodecSettings": {
+        "Codec": "H_264",
+        "H264Settings": {
+          "InterlaceMode": "PROGRESSIVE",
+          "ParNumerator": 1,
+          "NumberReferenceFrames": 3,
+          "Syntax": "DEFAULT",
+          "Softness": 0,
+          "FramerateDenominator": 1001,
+          "GopClosedCadence": 1,
+          "HrdBufferInitialFillPercentage": 90,
+          "GopSize": 2,
+          "Slices": 1,
+          "GopBReference": "ENABLED",
+          "HrdBufferSize": 9000000,
+          "MaxBitrate": 4500000,
+          "SlowPal": "DISABLED",
+          "ParDenominator": 1,
+          "SpatialAdaptiveQuantization": "ENABLED",
+          "TemporalAdaptiveQuantization": "ENABLED",
+          "FlickerAdaptiveQuantization": "ENABLED",
+          "EntropyEncoding": "CABAC",
+          "FramerateControl": "SPECIFIED",
+          "RateControlMode": "QVBR",
+          "QvbrSettings": {
+            "QvbrQualityLevel": 8
+          },
+          "CodecProfile": "HIGH",
+          "Telecine": "NONE",
+          "FramerateNumerator": 24000,
+          "MinIInterval": 0,
+          "AdaptiveQuantization": "HIGH",
+          "CodecLevel": "LEVEL_4",
+          "FieldEncoding": "PAFF",
+          "SceneChangeDetect": "ENABLED",
+          "QualityTuningLevel": "SINGLE_PASS_HQ",
+          "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+          "UnregisteredSeiTimecode": "DISABLED",
+          "GopSizeUnits": "SECONDS",
+          "ParControl": "SPECIFIED",
+          "NumberBFramesBetweenReferenceFrames": 3,
+          "RepeatPps": "DISABLED"
+        }
+      },
+      "AfdSignaling": "NONE",
+      "DropFrameTimecode": "ENABLED",
+      "RespondToAfd": "NONE",
+      "ColorMetadata": "INSERT"
+    },
+    "AudioDescriptions": [
+      {
+        "AudioTypeControl": "FOLLOW_INPUT",
+        "AudioSourceName": "Audio Selector 1",
+        "CodecSettings": {
+          "Codec": "AAC",
+          "AacSettings": {
+            "AudioDescriptionBroadcasterMix": "NORMAL",
+            "Bitrate": 160000,
+            "RateControlMode": "CBR",
+            "CodecProfile": "LC",
+            "CodingMode": "CODING_MODE_2_0",
+            "RawFormat": "NONE",
+            "SampleRate": 48000,
+            "Specification": "MPEG4"
+          }
+        },
+        "LanguageCodeControl": "FOLLOW_INPUT",
+        "AudioType": 0
+      }
+    ],
+    "ContainerSettings": {
+      "Container": "MP4",
+      "Mp4Settings": {
+        "CslgAtom": "INCLUDE",
+        "FreeSpaceBox": "EXCLUDE",
+        "MoovPlacement": "PROGRESSIVE_DOWNLOAD"
+      }
+    }
+  }
+}

--- a/source/custom-resource/lib/mediaconvert/presets/_Mp4_Avc_Aac_9x16_720x1280p_24Hz_4.5Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Mp4_Avc_Aac_9x16_720x1280p_24Hz_4.5Mbps_qvbr.json
@@ -1,99 +1,92 @@
 {
-  "Description": "video on demand on aws",
-  "Category": "VOD",
-  "Name": "_Mp4_Avc_Aac_9x16_720x1280p_24Hz_4.5Mbps_qvbr",
-  "Settings": {
-    "VideoDescription": {
-      "Width": 720,
-      "ScalingBehavior": "DEFAULT",
-      "Height": 1280,
-      "VideoPreprocessors": {
-        "Deinterlacer": {
-          "Algorithm": "INTERPOLATE",
-          "Mode": "DEINTERLACE",
-          "Control": "NORMAL"
-        }
-      },
-      "TimecodeInsertion": "DISABLED",
-      "AntiAlias": "ENABLED",
-      "Sharpness": 50,
-      "CodecSettings": {
-        "Codec": "H_264",
-        "H264Settings": {
-          "InterlaceMode": "PROGRESSIVE",
-          "ParNumerator": 1,
-          "NumberReferenceFrames": 3,
-          "Syntax": "DEFAULT",
-          "Softness": 0,
-          "FramerateDenominator": 1001,
-          "GopClosedCadence": 1,
-          "HrdBufferInitialFillPercentage": 90,
-          "GopSize": 2,
-          "Slices": 1,
-          "GopBReference": "ENABLED",
-          "HrdBufferSize": 9000000,
-          "MaxBitrate": 4500000,
-          "SlowPal": "DISABLED",
-          "ParDenominator": 1,
-          "SpatialAdaptiveQuantization": "ENABLED",
-          "TemporalAdaptiveQuantization": "ENABLED",
-          "FlickerAdaptiveQuantization": "ENABLED",
-          "EntropyEncoding": "CABAC",
-          "FramerateControl": "SPECIFIED",
-          "RateControlMode": "QVBR",
-          "QvbrSettings": {
-            "QvbrQualityLevel": 8
-          },
-          "CodecProfile": "HIGH",
-          "Telecine": "NONE",
-          "FramerateNumerator": 24000,
-          "MinIInterval": 0,
-          "AdaptiveQuantization": "HIGH",
-          "CodecLevel": "LEVEL_4",
-          "FieldEncoding": "PAFF",
-          "SceneChangeDetect": "ENABLED",
-          "QualityTuningLevel": "SINGLE_PASS_HQ",
-          "FramerateConversionAlgorithm": "DUPLICATE_DROP",
-          "UnregisteredSeiTimecode": "DISABLED",
-          "GopSizeUnits": "SECONDS",
-          "ParControl": "SPECIFIED",
-          "NumberBFramesBetweenReferenceFrames": 3,
-          "RepeatPps": "DISABLED"
-        }
-      },
-      "AfdSignaling": "NONE",
-      "DropFrameTimecode": "ENABLED",
-      "RespondToAfd": "NONE",
-      "ColorMetadata": "INSERT"
-    },
-    "AudioDescriptions": [
-      {
-        "AudioTypeControl": "FOLLOW_INPUT",
-        "AudioSourceName": "Audio Selector 1",
-        "CodecSettings": {
-          "Codec": "AAC",
-          "AacSettings": {
-            "AudioDescriptionBroadcasterMix": "NORMAL",
-            "Bitrate": 160000,
-            "RateControlMode": "CBR",
-            "CodecProfile": "LC",
-            "CodingMode": "CODING_MODE_2_0",
-            "RawFormat": "NONE",
-            "SampleRate": 48000,
-            "Specification": "MPEG4"
-          }
+  "VideoDescription": {
+    "CodecSettings": {
+      "Codec": "H_264",
+      "H264Settings": {
+        "CodecProfile": "HIGH",
+        "SpatialAdaptiveQuantization": "ENABLED",
+        "TemporalAdaptiveQuantization": "ENABLED",
+        "Softness": 0,
+        "Syntax": "DEFAULT",
+        "FramerateNumerator": 24000,
+        "MinIInterval": 0,
+        "UnregisteredSeiTimecode": "DISABLED",
+        "FramerateControl": "SPECIFIED",
+        "NumberReferenceFrames": 3,
+        "FramerateDenominator": 1001,
+        "QvbrSettings": {
+          "QvbrQualityLevel": 8
         },
-        "LanguageCodeControl": "FOLLOW_INPUT",
-        "AudioType": 0
+        "MaxBitrate": 4500000,
+        "RateControlMode": "QVBR",
+        "GopBReference": "ENABLED",
+        "EntropyEncoding": "CABAC",
+        "GopSizeUnits": "SECONDS",
+        "FlickerAdaptiveQuantization": "ENABLED",
+        "Telecine": "NONE",
+        "ParDenominator": 1,
+        "AdaptiveQuantization": "HIGH",
+        "InterlaceMode": "PROGRESSIVE",
+        "QualityTuningLevel": "SINGLE_PASS_HQ",
+        "HrdBufferInitialFillPercentage": 90,
+        "RepeatPps": "DISABLED",
+        "FieldEncoding": "PAFF",
+        "SlowPal": "DISABLED",
+        "GopClosedCadence": 1,
+        "GopSize": 2.0,
+        "ParControl": "SPECIFIED",
+        "Slices": 1,
+        "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+        "ParNumerator": 1,
+        "SceneChangeDetect": "ENABLED",
+        "CodecLevel": "LEVEL_4",
+        "NumberBFramesBetweenReferenceFrames": 3,
+        "HrdBufferSize": 9000000
       }
-    ],
-    "ContainerSettings": {
-      "Container": "MP4",
-      "Mp4Settings": {
-        "CslgAtom": "INCLUDE",
-        "FreeSpaceBox": "EXCLUDE",
-        "MoovPlacement": "PROGRESSIVE_DOWNLOAD"
+    },
+    "DropFrameTimecode": "ENABLED",
+    "VideoPreprocessors": {
+      "Deinterlacer": {
+        "Control": "NORMAL",
+        "Mode": "DEINTERLACE",
+        "Algorithm": "INTERPOLATE"
       }
-    }
+    },
+    "RespondToAfd": "NONE",
+    "Sharpness": 50,
+    "AfdSignaling": "NONE",
+    "Height": 1280,
+    "Width": 720,
+    "ScalingBehavior": "DEFAULT",
+    "ColorMetadata": "INSERT",
+    "AntiAlias": "ENABLED",
+    "TimecodeInsertion": "DISABLED"
+  },
+  "AudioDescriptions": [{
+    "CodecSettings": {
+      "Codec": "AAC",
+      "AacSettings": {
+        "CodecProfile": "LC",
+        "Specification": "MPEG4",
+        "RateControlMode": "CBR",
+        "AudioDescriptionBroadcasterMix": "NORMAL",
+        "SampleRate": 48000,
+        "Bitrate": 160000,
+        "CodingMode": "CODING_MODE_2_0",
+        "RawFormat": "NONE"
+      }
+    },
+    "AudioSourceName": "Audio Selector 1",
+    "AudioTypeControl": "FOLLOW_INPUT",
+    "LanguageCodeControl": "FOLLOW_INPUT",
+    "AudioType": 0
+  }],
+  "ContainerSettings": {
+    "Mp4Settings": {
+      "MoovPlacement": "PROGRESSIVE_DOWNLOAD",
+      "CslgAtom": "INCLUDE",
+      "FreeSpaceBox": "EXCLUDE"
+    },
+    "Container": "MP4"
   }
 }

--- a/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_1080x1920p_30Hz_8.5Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_1080x1920p_30Hz_8.5Mbps_qvbr.json
@@ -1,0 +1,72 @@
+{
+  "Description": "video on demand on aws",
+  "Category": "VOD",
+  "Name": "_Ott_Dash_Mp4_Avc_9x16_1080x1920p_30Hz_8.5Mbps_qvbr",
+  "Settings": {
+    "VideoDescription": {
+      "Width": 1080,
+      "ScalingBehavior": "DEFAULT",
+      "Height": 1920,
+      "VideoPreprocessors": {
+        "Deinterlacer": {
+          "Algorithm": "INTERPOLATE",
+          "Mode": "DEINTERLACE",
+          "Control": "NORMAL"
+        }
+      },
+      "TimecodeInsertion": "DISABLED",
+      "AntiAlias": "ENABLED",
+      "Sharpness": 50,
+      "CodecSettings": {
+        "Codec": "H_264",
+        "H264Settings": {
+          "InterlaceMode": "PROGRESSIVE",
+          "ParNumerator": 1,
+          "NumberReferenceFrames": 3,
+          "Syntax": "DEFAULT",
+          "FramerateDenominator": 1001,
+          "GopClosedCadence": 1,
+          "HrdBufferInitialFillPercentage": 90,
+          "GopSize": 90,
+          "Slices": 1,
+          "GopBReference": "DISABLED",
+          "HrdBufferSize": 17000000,
+          "MaxBitrate": 8500000,
+          "SlowPal": "DISABLED",
+          "ParDenominator": 1,
+          "SpatialAdaptiveQuantization": "ENABLED",
+          "TemporalAdaptiveQuantization": "ENABLED",
+          "FlickerAdaptiveQuantization": "ENABLED",
+          "EntropyEncoding": "CABAC",
+          "FramerateControl": "SPECIFIED",
+          "RateControlMode": "QVBR",
+          "QvbrSettings": {
+            "QvbrQualityLevel": 8
+          },
+          "CodecProfile": "HIGH",
+          "Telecine": "NONE",
+          "FramerateNumerator": 30000,
+          "MinIInterval": 0,
+          "AdaptiveQuantization": "HIGH",
+          "CodecLevel": "LEVEL_4",
+          "FieldEncoding": "PAFF",
+          "SceneChangeDetect": "ENABLED",
+          "QualityTuningLevel": "SINGLE_PASS_HQ",
+          "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+          "UnregisteredSeiTimecode": "DISABLED",
+          "GopSizeUnits": "FRAMES",
+          "ParControl": "SPECIFIED",
+          "NumberBFramesBetweenReferenceFrames": 1,
+          "RepeatPps": "DISABLED"
+        }
+      },
+      "AfdSignaling": "NONE",
+      "DropFrameTimecode": "ENABLED",
+      "RespondToAfd": "NONE",
+      "ColorMetadata": "INSERT"
+    },
+    "ContainerSettings": {
+      "Container": "MPD"
+    }
+  }
+}

--- a/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_1080x1920p_30Hz_8.5Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_1080x1920p_30Hz_8.5Mbps_qvbr.json
@@ -1,72 +1,67 @@
 {
-  "Description": "video on demand on aws",
-  "Category": "VOD",
-  "Name": "_Ott_Dash_Mp4_Avc_9x16_1080x1920p_30Hz_8.5Mbps_qvbr",
-  "Settings": {
-    "VideoDescription": {
-      "Width": 1080,
-      "ScalingBehavior": "DEFAULT",
-      "Height": 1920,
-      "VideoPreprocessors": {
-        "Deinterlacer": {
-          "Algorithm": "INTERPOLATE",
-          "Mode": "DEINTERLACE",
-          "Control": "NORMAL"
-        }
-      },
-      "TimecodeInsertion": "DISABLED",
-      "AntiAlias": "ENABLED",
-      "Sharpness": 50,
-      "CodecSettings": {
-        "Codec": "H_264",
-        "H264Settings": {
-          "InterlaceMode": "PROGRESSIVE",
-          "ParNumerator": 1,
-          "NumberReferenceFrames": 3,
-          "Syntax": "DEFAULT",
-          "FramerateDenominator": 1001,
-          "GopClosedCadence": 1,
-          "HrdBufferInitialFillPercentage": 90,
-          "GopSize": 90,
-          "Slices": 1,
-          "GopBReference": "DISABLED",
-          "HrdBufferSize": 17000000,
-          "MaxBitrate": 8500000,
-          "SlowPal": "DISABLED",
-          "ParDenominator": 1,
-          "SpatialAdaptiveQuantization": "ENABLED",
-          "TemporalAdaptiveQuantization": "ENABLED",
-          "FlickerAdaptiveQuantization": "ENABLED",
-          "EntropyEncoding": "CABAC",
-          "FramerateControl": "SPECIFIED",
-          "RateControlMode": "QVBR",
-          "QvbrSettings": {
-            "QvbrQualityLevel": 8
-          },
-          "CodecProfile": "HIGH",
-          "Telecine": "NONE",
-          "FramerateNumerator": 30000,
-          "MinIInterval": 0,
-          "AdaptiveQuantization": "HIGH",
-          "CodecLevel": "LEVEL_4",
-          "FieldEncoding": "PAFF",
-          "SceneChangeDetect": "ENABLED",
-          "QualityTuningLevel": "SINGLE_PASS_HQ",
-          "FramerateConversionAlgorithm": "DUPLICATE_DROP",
-          "UnregisteredSeiTimecode": "DISABLED",
-          "GopSizeUnits": "FRAMES",
-          "ParControl": "SPECIFIED",
-          "NumberBFramesBetweenReferenceFrames": 1,
-          "RepeatPps": "DISABLED"
-        }
-      },
-      "AfdSignaling": "NONE",
-      "DropFrameTimecode": "ENABLED",
-      "RespondToAfd": "NONE",
-      "ColorMetadata": "INSERT"
+  "VideoDescription": {
+    "CodecSettings": {
+      "Codec": "H_264",
+      "H264Settings": {
+        "CodecProfile": "HIGH",
+        "SpatialAdaptiveQuantization": "ENABLED",
+        "TemporalAdaptiveQuantization": "ENABLED",
+        "Syntax": "DEFAULT",
+        "FramerateNumerator": 30000,
+        "MinIInterval": 0,
+        "UnregisteredSeiTimecode": "DISABLED",
+        "FramerateControl": "SPECIFIED",
+        "NumberReferenceFrames": 3,
+        "FramerateDenominator": 1001,
+        "QvbrSettings": {
+          "QvbrQualityLevel": 8
+        },
+        "MaxBitrate": 8500000,
+        "RateControlMode": "QVBR",
+        "GopBReference": "DISABLED",
+        "EntropyEncoding": "CABAC",
+        "GopSizeUnits": "FRAMES",
+        "FlickerAdaptiveQuantization": "ENABLED",
+        "Telecine": "NONE",
+        "ParDenominator": 1,
+        "AdaptiveQuantization": "HIGH",
+        "InterlaceMode": "PROGRESSIVE",
+        "QualityTuningLevel": "SINGLE_PASS_HQ",
+        "HrdBufferInitialFillPercentage": 90,
+        "RepeatPps": "DISABLED",
+        "FieldEncoding": "PAFF",
+        "SlowPal": "DISABLED",
+        "GopClosedCadence": 1,
+        "GopSize": 90.0,
+        "ParControl": "SPECIFIED",
+        "Slices": 1,
+        "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+        "ParNumerator": 1,
+        "SceneChangeDetect": "ENABLED",
+        "CodecLevel": "LEVEL_4",
+        "NumberBFramesBetweenReferenceFrames": 1,
+        "HrdBufferSize": 17000000
+      }
     },
-    "ContainerSettings": {
-      "Container": "MPD"
-    }
+    "DropFrameTimecode": "ENABLED",
+    "VideoPreprocessors": {
+      "Deinterlacer": {
+        "Control": "NORMAL",
+        "Mode": "DEINTERLACE",
+        "Algorithm": "INTERPOLATE"
+      }
+    },
+    "RespondToAfd": "NONE",
+    "Sharpness": 50,
+    "AfdSignaling": "NONE",
+    "Height": 1920,
+    "Width": 1080,
+    "ScalingBehavior": "DEFAULT",
+    "ColorMetadata": "INSERT",
+    "AntiAlias": "ENABLED",
+    "TimecodeInsertion": "DISABLED"
+  },
+  "ContainerSettings": {
+    "Container": "MPD"
   }
 }

--- a/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_270x480p_15Hz_0.4Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_270x480p_15Hz_0.4Mbps_qvbr.json
@@ -1,0 +1,72 @@
+{
+  "Description": "video on demand on aws",
+  "Category": "VOD",
+  "Name": "_Ott_Dash_Mp4_Avc_9x16_270x480p_15Hz_0.4Mbps_qvbr",
+  "Settings": {
+    "VideoDescription": {
+      "Width": 270,
+      "ScalingBehavior": "DEFAULT",
+      "Height": 480,
+      "VideoPreprocessors": {
+        "Deinterlacer": {
+          "Algorithm": "INTERPOLATE",
+          "Mode": "DEINTERLACE",
+          "Control": "NORMAL"
+        }
+      },
+      "TimecodeInsertion": "DISABLED",
+      "AntiAlias": "ENABLED",
+      "Sharpness": 50,
+      "CodecSettings": {
+        "Codec": "H_264",
+        "H264Settings": {
+          "InterlaceMode": "PROGRESSIVE",
+          "ParNumerator": 1,
+          "NumberReferenceFrames": 3,
+          "Syntax": "DEFAULT",
+          "FramerateDenominator": 1001,
+          "GopClosedCadence": 1,
+          "HrdBufferInitialFillPercentage": 90,
+          "GopSize": 45,
+          "Slices": 1,
+          "GopBReference": "ENABLED",
+          "HrdBufferSize": 800000,
+          "MaxBitrate": 400000,
+          "SlowPal": "DISABLED",
+          "ParDenominator": 1,
+          "SpatialAdaptiveQuantization": "ENABLED",
+          "TemporalAdaptiveQuantization": "ENABLED",
+          "FlickerAdaptiveQuantization": "ENABLED",
+          "EntropyEncoding": "CABAC",
+          "FramerateControl": "SPECIFIED",
+          "RateControlMode": "QVBR",
+          "QvbrSettings": {
+            "QvbrQualityLevel": 7
+          },
+          "CodecProfile": "MAIN",
+          "Telecine": "NONE",
+          "FramerateNumerator": 15000,
+          "MinIInterval": 0,
+          "AdaptiveQuantization": "MEDIUM",
+          "CodecLevel": "LEVEL_3_1",
+          "FieldEncoding": "PAFF",
+          "SceneChangeDetect": "ENABLED",
+          "QualityTuningLevel": "SINGLE_PASS_HQ",
+          "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+          "UnregisteredSeiTimecode": "DISABLED",
+          "GopSizeUnits": "FRAMES",
+          "ParControl": "SPECIFIED",
+          "NumberBFramesBetweenReferenceFrames": 3,
+          "RepeatPps": "DISABLED"
+        }
+      },
+      "AfdSignaling": "NONE",
+      "DropFrameTimecode": "ENABLED",
+      "RespondToAfd": "NONE",
+      "ColorMetadata": "INSERT"
+    },
+    "ContainerSettings": {
+      "Container": "MPD"
+    }
+  }
+}

--- a/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_270x480p_15Hz_0.4Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_270x480p_15Hz_0.4Mbps_qvbr.json
@@ -1,72 +1,67 @@
 {
-  "Description": "video on demand on aws",
-  "Category": "VOD",
-  "Name": "_Ott_Dash_Mp4_Avc_9x16_270x480p_15Hz_0.4Mbps_qvbr",
-  "Settings": {
-    "VideoDescription": {
-      "Width": 270,
-      "ScalingBehavior": "DEFAULT",
-      "Height": 480,
-      "VideoPreprocessors": {
-        "Deinterlacer": {
-          "Algorithm": "INTERPOLATE",
-          "Mode": "DEINTERLACE",
-          "Control": "NORMAL"
-        }
-      },
-      "TimecodeInsertion": "DISABLED",
-      "AntiAlias": "ENABLED",
-      "Sharpness": 50,
-      "CodecSettings": {
-        "Codec": "H_264",
-        "H264Settings": {
-          "InterlaceMode": "PROGRESSIVE",
-          "ParNumerator": 1,
-          "NumberReferenceFrames": 3,
-          "Syntax": "DEFAULT",
-          "FramerateDenominator": 1001,
-          "GopClosedCadence": 1,
-          "HrdBufferInitialFillPercentage": 90,
-          "GopSize": 45,
-          "Slices": 1,
-          "GopBReference": "ENABLED",
-          "HrdBufferSize": 800000,
-          "MaxBitrate": 400000,
-          "SlowPal": "DISABLED",
-          "ParDenominator": 1,
-          "SpatialAdaptiveQuantization": "ENABLED",
-          "TemporalAdaptiveQuantization": "ENABLED",
-          "FlickerAdaptiveQuantization": "ENABLED",
-          "EntropyEncoding": "CABAC",
-          "FramerateControl": "SPECIFIED",
-          "RateControlMode": "QVBR",
-          "QvbrSettings": {
-            "QvbrQualityLevel": 7
-          },
-          "CodecProfile": "MAIN",
-          "Telecine": "NONE",
-          "FramerateNumerator": 15000,
-          "MinIInterval": 0,
-          "AdaptiveQuantization": "MEDIUM",
-          "CodecLevel": "LEVEL_3_1",
-          "FieldEncoding": "PAFF",
-          "SceneChangeDetect": "ENABLED",
-          "QualityTuningLevel": "SINGLE_PASS_HQ",
-          "FramerateConversionAlgorithm": "DUPLICATE_DROP",
-          "UnregisteredSeiTimecode": "DISABLED",
-          "GopSizeUnits": "FRAMES",
-          "ParControl": "SPECIFIED",
-          "NumberBFramesBetweenReferenceFrames": 3,
-          "RepeatPps": "DISABLED"
-        }
-      },
-      "AfdSignaling": "NONE",
-      "DropFrameTimecode": "ENABLED",
-      "RespondToAfd": "NONE",
-      "ColorMetadata": "INSERT"
+  "VideoDescription": {
+    "CodecSettings": {
+      "Codec": "H_264",
+      "H264Settings": {
+        "CodecProfile": "MAIN",
+        "SpatialAdaptiveQuantization": "ENABLED",
+        "TemporalAdaptiveQuantization": "ENABLED",
+        "Syntax": "DEFAULT",
+        "FramerateNumerator": 15000,
+        "MinIInterval": 0,
+        "UnregisteredSeiTimecode": "DISABLED",
+        "FramerateControl": "SPECIFIED",
+        "NumberReferenceFrames": 3,
+        "FramerateDenominator": 1001,
+        "QvbrSettings": {
+          "QvbrQualityLevel": 7
+        },
+        "MaxBitrate": 400000,
+        "RateControlMode": "QVBR",
+        "GopBReference": "ENABLED",
+        "EntropyEncoding": "CABAC",
+        "GopSizeUnits": "FRAMES",
+        "FlickerAdaptiveQuantization": "ENABLED",
+        "Telecine": "NONE",
+        "ParDenominator": 1,
+        "AdaptiveQuantization": "MEDIUM",
+        "InterlaceMode": "PROGRESSIVE",
+        "QualityTuningLevel": "SINGLE_PASS_HQ",
+        "HrdBufferInitialFillPercentage": 90,
+        "RepeatPps": "DISABLED",
+        "FieldEncoding": "PAFF",
+        "SlowPal": "DISABLED",
+        "GopClosedCadence": 1,
+        "GopSize": 45.0,
+        "ParControl": "SPECIFIED",
+        "Slices": 1,
+        "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+        "ParNumerator": 1,
+        "SceneChangeDetect": "ENABLED",
+        "CodecLevel": "LEVEL_3_1",
+        "NumberBFramesBetweenReferenceFrames": 3,
+        "HrdBufferSize": 800000
+      }
     },
-    "ContainerSettings": {
-      "Container": "MPD"
-    }
+    "DropFrameTimecode": "ENABLED",
+    "VideoPreprocessors": {
+      "Deinterlacer": {
+        "Control": "NORMAL",
+        "Mode": "DEINTERLACE",
+        "Algorithm": "INTERPOLATE"
+      }
+    },
+    "RespondToAfd": "NONE",
+    "Sharpness": 50,
+    "AfdSignaling": "NONE",
+    "Height": 480,
+    "Width": 270,
+    "ScalingBehavior": "DEFAULT",
+    "ColorMetadata": "INSERT",
+    "AntiAlias": "ENABLED",
+    "TimecodeInsertion": "DISABLED"
+  },
+  "ContainerSettings": {
+    "Container": "MPD"
   }
 }

--- a/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_0.6Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_0.6Mbps_qvbr.json
@@ -1,0 +1,72 @@
+{
+  "Description": "video on demand on aws",
+  "Category": "VOD",
+  "Name": "_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_0.6Mbps_qvbr",
+  "Settings": {
+    "VideoDescription": {
+      "Width": 360,
+      "ScalingBehavior": "DEFAULT",
+      "Height": 640,
+      "VideoPreprocessors": {
+        "Deinterlacer": {
+          "Algorithm": "INTERPOLATE",
+          "Mode": "DEINTERLACE",
+          "Control": "NORMAL"
+        }
+      },
+      "TimecodeInsertion": "DISABLED",
+      "AntiAlias": "ENABLED",
+      "Sharpness": 50,
+      "CodecSettings": {
+        "Codec": "H_264",
+        "H264Settings": {
+          "InterlaceMode": "PROGRESSIVE",
+          "ParNumerator": 1,
+          "NumberReferenceFrames": 3,
+          "Syntax": "DEFAULT",
+          "FramerateDenominator": 1001,
+          "GopClosedCadence": 1,
+          "HrdBufferInitialFillPercentage": 90,
+          "GopSize": 90,
+          "Slices": 1,
+          "GopBReference": "ENABLED",
+          "HrdBufferSize": 1200000,
+          "MaxBitrate": 600000,
+          "SlowPal": "DISABLED",
+          "ParDenominator": 1,
+          "SpatialAdaptiveQuantization": "ENABLED",
+          "TemporalAdaptiveQuantization": "ENABLED",
+          "FlickerAdaptiveQuantization": "ENABLED",
+          "EntropyEncoding": "CABAC",
+          "FramerateControl": "SPECIFIED",
+          "RateControlMode": "QVBR",
+          "QvbrSettings": {
+            "QvbrQualityLevel": 8
+          },
+          "CodecProfile": "MAIN",
+          "Telecine": "NONE",
+          "FramerateNumerator": 30000,
+          "MinIInterval": 0,
+          "AdaptiveQuantization": "MEDIUM",
+          "CodecLevel": "LEVEL_3_1",
+          "FieldEncoding": "PAFF",
+          "SceneChangeDetect": "ENABLED",
+          "QualityTuningLevel": "SINGLE_PASS_HQ",
+          "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+          "UnregisteredSeiTimecode": "DISABLED",
+          "GopSizeUnits": "FRAMES",
+          "ParControl": "SPECIFIED",
+          "NumberBFramesBetweenReferenceFrames": 3,
+          "RepeatPps": "DISABLED"
+        }
+      },
+      "AfdSignaling": "NONE",
+      "DropFrameTimecode": "ENABLED",
+      "RespondToAfd": "NONE",
+      "ColorMetadata": "INSERT"
+    },
+    "ContainerSettings": {
+      "Container": "MPD"
+    }
+  }
+}

--- a/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_0.6Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_0.6Mbps_qvbr.json
@@ -1,72 +1,67 @@
 {
-  "Description": "video on demand on aws",
-  "Category": "VOD",
-  "Name": "_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_0.6Mbps_qvbr",
-  "Settings": {
-    "VideoDescription": {
-      "Width": 360,
-      "ScalingBehavior": "DEFAULT",
-      "Height": 640,
-      "VideoPreprocessors": {
-        "Deinterlacer": {
-          "Algorithm": "INTERPOLATE",
-          "Mode": "DEINTERLACE",
-          "Control": "NORMAL"
-        }
-      },
-      "TimecodeInsertion": "DISABLED",
-      "AntiAlias": "ENABLED",
-      "Sharpness": 50,
-      "CodecSettings": {
-        "Codec": "H_264",
-        "H264Settings": {
-          "InterlaceMode": "PROGRESSIVE",
-          "ParNumerator": 1,
-          "NumberReferenceFrames": 3,
-          "Syntax": "DEFAULT",
-          "FramerateDenominator": 1001,
-          "GopClosedCadence": 1,
-          "HrdBufferInitialFillPercentage": 90,
-          "GopSize": 90,
-          "Slices": 1,
-          "GopBReference": "ENABLED",
-          "HrdBufferSize": 1200000,
-          "MaxBitrate": 600000,
-          "SlowPal": "DISABLED",
-          "ParDenominator": 1,
-          "SpatialAdaptiveQuantization": "ENABLED",
-          "TemporalAdaptiveQuantization": "ENABLED",
-          "FlickerAdaptiveQuantization": "ENABLED",
-          "EntropyEncoding": "CABAC",
-          "FramerateControl": "SPECIFIED",
-          "RateControlMode": "QVBR",
-          "QvbrSettings": {
-            "QvbrQualityLevel": 8
-          },
-          "CodecProfile": "MAIN",
-          "Telecine": "NONE",
-          "FramerateNumerator": 30000,
-          "MinIInterval": 0,
-          "AdaptiveQuantization": "MEDIUM",
-          "CodecLevel": "LEVEL_3_1",
-          "FieldEncoding": "PAFF",
-          "SceneChangeDetect": "ENABLED",
-          "QualityTuningLevel": "SINGLE_PASS_HQ",
-          "FramerateConversionAlgorithm": "DUPLICATE_DROP",
-          "UnregisteredSeiTimecode": "DISABLED",
-          "GopSizeUnits": "FRAMES",
-          "ParControl": "SPECIFIED",
-          "NumberBFramesBetweenReferenceFrames": 3,
-          "RepeatPps": "DISABLED"
-        }
-      },
-      "AfdSignaling": "NONE",
-      "DropFrameTimecode": "ENABLED",
-      "RespondToAfd": "NONE",
-      "ColorMetadata": "INSERT"
+  "VideoDescription": {
+    "CodecSettings": {
+      "Codec": "H_264",
+      "H264Settings": {
+        "CodecProfile": "MAIN",
+        "SpatialAdaptiveQuantization": "ENABLED",
+        "TemporalAdaptiveQuantization": "ENABLED",
+        "Syntax": "DEFAULT",
+        "FramerateNumerator": 30000,
+        "MinIInterval": 0,
+        "UnregisteredSeiTimecode": "DISABLED",
+        "FramerateControl": "SPECIFIED",
+        "NumberReferenceFrames": 3,
+        "FramerateDenominator": 1001,
+        "QvbrSettings": {
+          "QvbrQualityLevel": 8
+        },
+        "MaxBitrate": 600000,
+        "RateControlMode": "QVBR",
+        "GopBReference": "ENABLED",
+        "EntropyEncoding": "CABAC",
+        "GopSizeUnits": "FRAMES",
+        "FlickerAdaptiveQuantization": "ENABLED",
+        "Telecine": "NONE",
+        "ParDenominator": 1,
+        "AdaptiveQuantization": "MEDIUM",
+        "InterlaceMode": "PROGRESSIVE",
+        "QualityTuningLevel": "SINGLE_PASS_HQ",
+        "HrdBufferInitialFillPercentage": 90,
+        "RepeatPps": "DISABLED",
+        "FieldEncoding": "PAFF",
+        "SlowPal": "DISABLED",
+        "GopClosedCadence": 1,
+        "GopSize": 90.0,
+        "ParControl": "SPECIFIED",
+        "Slices": 1,
+        "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+        "ParNumerator": 1,
+        "SceneChangeDetect": "ENABLED",
+        "CodecLevel": "LEVEL_3_1",
+        "NumberBFramesBetweenReferenceFrames": 3,
+        "HrdBufferSize": 1200000
+      }
     },
-    "ContainerSettings": {
-      "Container": "MPD"
-    }
+    "DropFrameTimecode": "ENABLED",
+    "VideoPreprocessors": {
+      "Deinterlacer": {
+        "Control": "NORMAL",
+        "Mode": "DEINTERLACE",
+        "Algorithm": "INTERPOLATE"
+      }
+    },
+    "RespondToAfd": "NONE",
+    "Sharpness": 50,
+    "AfdSignaling": "NONE",
+    "Height": 640,
+    "Width": 360,
+    "ScalingBehavior": "DEFAULT",
+    "ColorMetadata": "INSERT",
+    "AntiAlias": "ENABLED",
+    "TimecodeInsertion": "DISABLED"
+  },
+  "ContainerSettings": {
+    "Container": "MPD"
   }
 }

--- a/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_1.2Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_1.2Mbps_qvbr.json
@@ -1,0 +1,72 @@
+{
+  "Description": "video on demand on aws",
+  "Category": "VOD",
+  "Name": "_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_1.2Mbps_qvbr",
+  "Settings": {
+    "VideoDescription": {
+      "Width": 360,
+      "ScalingBehavior": "DEFAULT",
+      "Height": 640,
+      "VideoPreprocessors": {
+        "Deinterlacer": {
+          "Algorithm": "INTERPOLATE",
+          "Mode": "DEINTERLACE",
+          "Control": "NORMAL"
+        }
+      },
+      "TimecodeInsertion": "DISABLED",
+      "AntiAlias": "ENABLED",
+      "Sharpness": 50,
+      "CodecSettings": {
+        "Codec": "H_264",
+        "H264Settings": {
+          "InterlaceMode": "PROGRESSIVE",
+          "ParNumerator": 1,
+          "NumberReferenceFrames": 3,
+          "Syntax": "DEFAULT",
+          "FramerateDenominator": 1001,
+          "GopClosedCadence": 1,
+          "HrdBufferInitialFillPercentage": 90,
+          "GopSize": 90,
+          "Slices": 1,
+          "GopBReference": "ENABLED",
+          "HrdBufferSize": 2400000,
+          "MaxBitrate": 1200000,
+          "SlowPal": "DISABLED",
+          "ParDenominator": 1,
+          "SpatialAdaptiveQuantization": "ENABLED",
+          "TemporalAdaptiveQuantization": "ENABLED",
+          "FlickerAdaptiveQuantization": "ENABLED",
+          "EntropyEncoding": "CABAC",
+          "FramerateControl": "SPECIFIED",
+          "RateControlMode": "QVBR",
+          "QvbrSettings": {
+            "QvbrQualityLevel": 7
+          },
+          "CodecProfile": "MAIN",
+          "Telecine": "NONE",
+          "FramerateNumerator": 30000,
+          "MinIInterval": 0,
+          "AdaptiveQuantization": "MEDIUM",
+          "CodecLevel": "LEVEL_3_1",
+          "FieldEncoding": "PAFF",
+          "SceneChangeDetect": "ENABLED",
+          "QualityTuningLevel": "SINGLE_PASS_HQ",
+          "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+          "UnregisteredSeiTimecode": "DISABLED",
+          "GopSizeUnits": "FRAMES",
+          "ParControl": "SPECIFIED",
+          "NumberBFramesBetweenReferenceFrames": 3,
+          "RepeatPps": "DISABLED"
+        }
+      },
+      "AfdSignaling": "NONE",
+      "DropFrameTimecode": "ENABLED",
+      "RespondToAfd": "NONE",
+      "ColorMetadata": "INSERT"
+    },
+    "ContainerSettings": {
+      "Container": "MPD"
+    }
+  }
+}

--- a/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_1.2Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_1.2Mbps_qvbr.json
@@ -1,72 +1,67 @@
 {
-  "Description": "video on demand on aws",
-  "Category": "VOD",
-  "Name": "_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_1.2Mbps_qvbr",
-  "Settings": {
-    "VideoDescription": {
-      "Width": 360,
-      "ScalingBehavior": "DEFAULT",
-      "Height": 640,
-      "VideoPreprocessors": {
-        "Deinterlacer": {
-          "Algorithm": "INTERPOLATE",
-          "Mode": "DEINTERLACE",
-          "Control": "NORMAL"
-        }
-      },
-      "TimecodeInsertion": "DISABLED",
-      "AntiAlias": "ENABLED",
-      "Sharpness": 50,
-      "CodecSettings": {
-        "Codec": "H_264",
-        "H264Settings": {
-          "InterlaceMode": "PROGRESSIVE",
-          "ParNumerator": 1,
-          "NumberReferenceFrames": 3,
-          "Syntax": "DEFAULT",
-          "FramerateDenominator": 1001,
-          "GopClosedCadence": 1,
-          "HrdBufferInitialFillPercentage": 90,
-          "GopSize": 90,
-          "Slices": 1,
-          "GopBReference": "ENABLED",
-          "HrdBufferSize": 2400000,
-          "MaxBitrate": 1200000,
-          "SlowPal": "DISABLED",
-          "ParDenominator": 1,
-          "SpatialAdaptiveQuantization": "ENABLED",
-          "TemporalAdaptiveQuantization": "ENABLED",
-          "FlickerAdaptiveQuantization": "ENABLED",
-          "EntropyEncoding": "CABAC",
-          "FramerateControl": "SPECIFIED",
-          "RateControlMode": "QVBR",
-          "QvbrSettings": {
-            "QvbrQualityLevel": 7
-          },
-          "CodecProfile": "MAIN",
-          "Telecine": "NONE",
-          "FramerateNumerator": 30000,
-          "MinIInterval": 0,
-          "AdaptiveQuantization": "MEDIUM",
-          "CodecLevel": "LEVEL_3_1",
-          "FieldEncoding": "PAFF",
-          "SceneChangeDetect": "ENABLED",
-          "QualityTuningLevel": "SINGLE_PASS_HQ",
-          "FramerateConversionAlgorithm": "DUPLICATE_DROP",
-          "UnregisteredSeiTimecode": "DISABLED",
-          "GopSizeUnits": "FRAMES",
-          "ParControl": "SPECIFIED",
-          "NumberBFramesBetweenReferenceFrames": 3,
-          "RepeatPps": "DISABLED"
-        }
-      },
-      "AfdSignaling": "NONE",
-      "DropFrameTimecode": "ENABLED",
-      "RespondToAfd": "NONE",
-      "ColorMetadata": "INSERT"
+  "VideoDescription": {
+    "CodecSettings": {
+      "Codec": "H_264",
+      "H264Settings": {
+        "CodecProfile": "MAIN",
+        "SpatialAdaptiveQuantization": "ENABLED",
+        "TemporalAdaptiveQuantization": "ENABLED",
+        "Syntax": "DEFAULT",
+        "FramerateNumerator": 30000,
+        "MinIInterval": 0,
+        "UnregisteredSeiTimecode": "DISABLED",
+        "FramerateControl": "SPECIFIED",
+        "NumberReferenceFrames": 3,
+        "FramerateDenominator": 1001,
+        "QvbrSettings": {
+          "QvbrQualityLevel": 7
+        },
+        "MaxBitrate": 1200000,
+        "RateControlMode": "QVBR",
+        "GopBReference": "ENABLED",
+        "EntropyEncoding": "CABAC",
+        "GopSizeUnits": "FRAMES",
+        "FlickerAdaptiveQuantization": "ENABLED",
+        "Telecine": "NONE",
+        "ParDenominator": 1,
+        "AdaptiveQuantization": "MEDIUM",
+        "InterlaceMode": "PROGRESSIVE",
+        "QualityTuningLevel": "SINGLE_PASS_HQ",
+        "HrdBufferInitialFillPercentage": 90,
+        "RepeatPps": "DISABLED",
+        "FieldEncoding": "PAFF",
+        "SlowPal": "DISABLED",
+        "GopClosedCadence": 1,
+        "GopSize": 90.0,
+        "ParControl": "SPECIFIED",
+        "Slices": 1,
+        "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+        "ParNumerator": 1,
+        "SceneChangeDetect": "ENABLED",
+        "CodecLevel": "LEVEL_3_1",
+        "NumberBFramesBetweenReferenceFrames": 3,
+        "HrdBufferSize": 2400000
+      }
     },
-    "ContainerSettings": {
-      "Container": "MPD"
-    }
+    "DropFrameTimecode": "ENABLED",
+    "VideoPreprocessors": {
+      "Deinterlacer": {
+        "Control": "NORMAL",
+        "Mode": "DEINTERLACE",
+        "Algorithm": "INTERPOLATE"
+      }
+    },
+    "RespondToAfd": "NONE",
+    "Sharpness": 50,
+    "AfdSignaling": "NONE",
+    "Height": 640,
+    "Width": 360,
+    "ScalingBehavior": "DEFAULT",
+    "ColorMetadata": "INSERT",
+    "AntiAlias": "ENABLED",
+    "TimecodeInsertion": "DISABLED"
+  },
+  "ContainerSettings": {
+    "Container": "MPD"
   }
 }

--- a/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_540x960p_30Hz_3.5Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_540x960p_30Hz_3.5Mbps_qvbr.json
@@ -1,72 +1,67 @@
 {
-  "Description": "video on demand on aws",
-  "Category": "VOD",
-  "Name": "_Ott_Dash_Mp4_Avc_9x16_540x960p_30Hz_3.5Mbps_qvbr",
-  "Settings": {
-    "VideoDescription": {
-      "Width": 540,
-      "ScalingBehavior": "DEFAULT",
-      "Height": 960,
-      "VideoPreprocessors": {
-        "Deinterlacer": {
-          "Algorithm": "INTERPOLATE",
-          "Mode": "DEINTERLACE",
-          "Control": "NORMAL"
-        }
-      },
-      "TimecodeInsertion": "DISABLED",
-      "AntiAlias": "ENABLED",
-      "Sharpness": 50,
-      "CodecSettings": {
-        "Codec": "H_264",
-        "H264Settings": {
-          "InterlaceMode": "PROGRESSIVE",
-          "ParNumerator": 1,
-          "NumberReferenceFrames": 3,
-          "Syntax": "DEFAULT",
-          "FramerateDenominator": 1001,
-          "GopClosedCadence": 1,
-          "HrdBufferInitialFillPercentage": 90,
-          "GopSize": 90,
-          "Slices": 1,
-          "GopBReference": "ENABLED",
-          "HrdBufferSize": 7000000,
-          "MaxBitrate": 3500000,
-          "SlowPal": "DISABLED",
-          "ParDenominator": 1,
-          "SpatialAdaptiveQuantization": "ENABLED",
-          "TemporalAdaptiveQuantization": "ENABLED",
-          "FlickerAdaptiveQuantization": "ENABLED",
-          "EntropyEncoding": "CABAC",
-          "FramerateControl": "SPECIFIED",
-          "RateControlMode": "QVBR",
-          "QvbrSettings": {
-            "QvbrQualityLevel": 7
-          },
-          "CodecProfile": "HIGH",
-          "Telecine": "NONE",
-          "FramerateNumerator": 30000,
-          "MinIInterval": 0,
-          "AdaptiveQuantization": "HIGH",
-          "CodecLevel": "LEVEL_4",
-          "FieldEncoding": "PAFF",
-          "SceneChangeDetect": "ENABLED",
-          "QualityTuningLevel": "SINGLE_PASS_HQ",
-          "FramerateConversionAlgorithm": "DUPLICATE_DROP",
-          "UnregisteredSeiTimecode": "DISABLED",
-          "GopSizeUnits": "FRAMES",
-          "ParControl": "SPECIFIED",
-          "NumberBFramesBetweenReferenceFrames": 3,
-          "RepeatPps": "DISABLED"
-        }
-      },
-      "AfdSignaling": "NONE",
-      "DropFrameTimecode": "ENABLED",
-      "RespondToAfd": "NONE",
-      "ColorMetadata": "INSERT"
+  "VideoDescription": {
+    "CodecSettings": {
+      "Codec": "H_264",
+      "H264Settings": {
+        "CodecProfile": "HIGH",
+        "SpatialAdaptiveQuantization": "ENABLED",
+        "TemporalAdaptiveQuantization": "ENABLED",
+        "Syntax": "DEFAULT",
+        "FramerateNumerator": 30000,
+        "MinIInterval": 0,
+        "UnregisteredSeiTimecode": "DISABLED",
+        "FramerateControl": "SPECIFIED",
+        "NumberReferenceFrames": 3,
+        "FramerateDenominator": 1001,
+        "QvbrSettings": {
+          "QvbrQualityLevel": 7
+        },
+        "MaxBitrate": 3500000,
+        "RateControlMode": "QVBR",
+        "GopBReference": "ENABLED",
+        "EntropyEncoding": "CABAC",
+        "GopSizeUnits": "FRAMES",
+        "FlickerAdaptiveQuantization": "ENABLED",
+        "Telecine": "NONE",
+        "ParDenominator": 1,
+        "AdaptiveQuantization": "HIGH",
+        "InterlaceMode": "PROGRESSIVE",
+        "QualityTuningLevel": "SINGLE_PASS_HQ",
+        "HrdBufferInitialFillPercentage": 90,
+        "RepeatPps": "DISABLED",
+        "FieldEncoding": "PAFF",
+        "SlowPal": "DISABLED",
+        "GopClosedCadence": 1,
+        "GopSize": 90.0,
+        "ParControl": "SPECIFIED",
+        "Slices": 1,
+        "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+        "ParNumerator": 1,
+        "SceneChangeDetect": "ENABLED",
+        "CodecLevel": "LEVEL_4",
+        "NumberBFramesBetweenReferenceFrames": 3,
+        "HrdBufferSize": 7000000
+      }
     },
-    "ContainerSettings": {
-      "Container": "MPD"
-    }
+    "DropFrameTimecode": "ENABLED",
+    "VideoPreprocessors": {
+      "Deinterlacer": {
+        "Control": "NORMAL",
+        "Mode": "DEINTERLACE",
+        "Algorithm": "INTERPOLATE"
+      }
+    },
+    "RespondToAfd": "NONE",
+    "Sharpness": 50,
+    "AfdSignaling": "NONE",
+    "Height": 960,
+    "Width": 540,
+    "ScalingBehavior": "DEFAULT",
+    "ColorMetadata": "INSERT",
+    "AntiAlias": "ENABLED",
+    "TimecodeInsertion": "DISABLED"
+  },
+  "ContainerSettings": {
+    "Container": "MPD"
   }
 }

--- a/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_540x960p_30Hz_3.5Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_540x960p_30Hz_3.5Mbps_qvbr.json
@@ -1,0 +1,72 @@
+{
+  "Description": "video on demand on aws",
+  "Category": "VOD",
+  "Name": "_Ott_Dash_Mp4_Avc_9x16_540x960p_30Hz_3.5Mbps_qvbr",
+  "Settings": {
+    "VideoDescription": {
+      "Width": 540,
+      "ScalingBehavior": "DEFAULT",
+      "Height": 960,
+      "VideoPreprocessors": {
+        "Deinterlacer": {
+          "Algorithm": "INTERPOLATE",
+          "Mode": "DEINTERLACE",
+          "Control": "NORMAL"
+        }
+      },
+      "TimecodeInsertion": "DISABLED",
+      "AntiAlias": "ENABLED",
+      "Sharpness": 50,
+      "CodecSettings": {
+        "Codec": "H_264",
+        "H264Settings": {
+          "InterlaceMode": "PROGRESSIVE",
+          "ParNumerator": 1,
+          "NumberReferenceFrames": 3,
+          "Syntax": "DEFAULT",
+          "FramerateDenominator": 1001,
+          "GopClosedCadence": 1,
+          "HrdBufferInitialFillPercentage": 90,
+          "GopSize": 90,
+          "Slices": 1,
+          "GopBReference": "ENABLED",
+          "HrdBufferSize": 7000000,
+          "MaxBitrate": 3500000,
+          "SlowPal": "DISABLED",
+          "ParDenominator": 1,
+          "SpatialAdaptiveQuantization": "ENABLED",
+          "TemporalAdaptiveQuantization": "ENABLED",
+          "FlickerAdaptiveQuantization": "ENABLED",
+          "EntropyEncoding": "CABAC",
+          "FramerateControl": "SPECIFIED",
+          "RateControlMode": "QVBR",
+          "QvbrSettings": {
+            "QvbrQualityLevel": 7
+          },
+          "CodecProfile": "HIGH",
+          "Telecine": "NONE",
+          "FramerateNumerator": 30000,
+          "MinIInterval": 0,
+          "AdaptiveQuantization": "HIGH",
+          "CodecLevel": "LEVEL_4",
+          "FieldEncoding": "PAFF",
+          "SceneChangeDetect": "ENABLED",
+          "QualityTuningLevel": "SINGLE_PASS_HQ",
+          "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+          "UnregisteredSeiTimecode": "DISABLED",
+          "GopSizeUnits": "FRAMES",
+          "ParControl": "SPECIFIED",
+          "NumberBFramesBetweenReferenceFrames": 3,
+          "RepeatPps": "DISABLED"
+        }
+      },
+      "AfdSignaling": "NONE",
+      "DropFrameTimecode": "ENABLED",
+      "RespondToAfd": "NONE",
+      "ColorMetadata": "INSERT"
+    },
+    "ContainerSettings": {
+      "Container": "MPD"
+    }
+  }
+}

--- a/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_3.5Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_3.5Mbps_qvbr.json
@@ -1,0 +1,72 @@
+{
+  "Description": "video on demand on aws",
+  "Category": "VOD",
+  "Name": "_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_3.5Mbps_qvbr",
+  "Settings": {
+    "VideoDescription": {
+      "Width": 720,
+      "ScalingBehavior": "DEFAULT",
+      "Height": 1280,
+      "VideoPreprocessors": {
+        "Deinterlacer": {
+          "Algorithm": "INTERPOLATE",
+          "Mode": "DEINTERLACE",
+          "Control": "NORMAL"
+        }
+      },
+      "TimecodeInsertion": "DISABLED",
+      "AntiAlias": "ENABLED",
+      "Sharpness": 50,
+      "CodecSettings": {
+        "Codec": "H_264",
+        "H264Settings": {
+          "InterlaceMode": "PROGRESSIVE",
+          "ParNumerator": 1,
+          "NumberReferenceFrames": 3,
+          "Syntax": "DEFAULT",
+          "FramerateDenominator": 1001,
+          "GopClosedCadence": 1,
+          "HrdBufferInitialFillPercentage": 90,
+          "GopSize": 90,
+          "Slices": 1,
+          "GopBReference": "ENABLED",
+          "HrdBufferSize": 7000000,
+          "MaxBitrate": 3500000,
+          "SlowPal": "DISABLED",
+          "ParDenominator": 1,
+          "SpatialAdaptiveQuantization": "ENABLED",
+          "TemporalAdaptiveQuantization": "ENABLED",
+          "FlickerAdaptiveQuantization": "ENABLED",
+          "EntropyEncoding": "CABAC",
+          "FramerateControl": "SPECIFIED",
+          "RateControlMode": "QVBR",
+          "QvbrSettings": {
+            "QvbrQualityLevel": 7
+          },
+          "CodecProfile": "HIGH",
+          "Telecine": "NONE",
+          "FramerateNumerator": 30000,
+          "MinIInterval": 0,
+          "AdaptiveQuantization": "HIGH",
+          "CodecLevel": "LEVEL_4",
+          "FieldEncoding": "PAFF",
+          "SceneChangeDetect": "ENABLED",
+          "QualityTuningLevel": "SINGLE_PASS_HQ",
+          "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+          "UnregisteredSeiTimecode": "DISABLED",
+          "GopSizeUnits": "FRAMES",
+          "ParControl": "SPECIFIED",
+          "NumberBFramesBetweenReferenceFrames": 3,
+          "RepeatPps": "DISABLED"
+        }
+      },
+      "AfdSignaling": "NONE",
+      "DropFrameTimecode": "ENABLED",
+      "RespondToAfd": "NONE",
+      "ColorMetadata": "INSERT"
+    },
+    "ContainerSettings": {
+      "Container": "MPD"
+    }
+  }
+}

--- a/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_3.5Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_3.5Mbps_qvbr.json
@@ -1,72 +1,67 @@
 {
-  "Description": "video on demand on aws",
-  "Category": "VOD",
-  "Name": "_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_3.5Mbps_qvbr",
-  "Settings": {
-    "VideoDescription": {
-      "Width": 720,
-      "ScalingBehavior": "DEFAULT",
-      "Height": 1280,
-      "VideoPreprocessors": {
-        "Deinterlacer": {
-          "Algorithm": "INTERPOLATE",
-          "Mode": "DEINTERLACE",
-          "Control": "NORMAL"
-        }
-      },
-      "TimecodeInsertion": "DISABLED",
-      "AntiAlias": "ENABLED",
-      "Sharpness": 50,
-      "CodecSettings": {
-        "Codec": "H_264",
-        "H264Settings": {
-          "InterlaceMode": "PROGRESSIVE",
-          "ParNumerator": 1,
-          "NumberReferenceFrames": 3,
-          "Syntax": "DEFAULT",
-          "FramerateDenominator": 1001,
-          "GopClosedCadence": 1,
-          "HrdBufferInitialFillPercentage": 90,
-          "GopSize": 90,
-          "Slices": 1,
-          "GopBReference": "ENABLED",
-          "HrdBufferSize": 7000000,
-          "MaxBitrate": 3500000,
-          "SlowPal": "DISABLED",
-          "ParDenominator": 1,
-          "SpatialAdaptiveQuantization": "ENABLED",
-          "TemporalAdaptiveQuantization": "ENABLED",
-          "FlickerAdaptiveQuantization": "ENABLED",
-          "EntropyEncoding": "CABAC",
-          "FramerateControl": "SPECIFIED",
-          "RateControlMode": "QVBR",
-          "QvbrSettings": {
-            "QvbrQualityLevel": 7
-          },
-          "CodecProfile": "HIGH",
-          "Telecine": "NONE",
-          "FramerateNumerator": 30000,
-          "MinIInterval": 0,
-          "AdaptiveQuantization": "HIGH",
-          "CodecLevel": "LEVEL_4",
-          "FieldEncoding": "PAFF",
-          "SceneChangeDetect": "ENABLED",
-          "QualityTuningLevel": "SINGLE_PASS_HQ",
-          "FramerateConversionAlgorithm": "DUPLICATE_DROP",
-          "UnregisteredSeiTimecode": "DISABLED",
-          "GopSizeUnits": "FRAMES",
-          "ParControl": "SPECIFIED",
-          "NumberBFramesBetweenReferenceFrames": 3,
-          "RepeatPps": "DISABLED"
-        }
-      },
-      "AfdSignaling": "NONE",
-      "DropFrameTimecode": "ENABLED",
-      "RespondToAfd": "NONE",
-      "ColorMetadata": "INSERT"
+  "VideoDescription": {
+    "CodecSettings": {
+      "Codec": "H_264",
+      "H264Settings": {
+        "CodecProfile": "HIGH",
+        "SpatialAdaptiveQuantization": "ENABLED",
+        "TemporalAdaptiveQuantization": "ENABLED",
+        "Syntax": "DEFAULT",
+        "FramerateNumerator": 30000,
+        "MinIInterval": 0,
+        "UnregisteredSeiTimecode": "DISABLED",
+        "FramerateControl": "SPECIFIED",
+        "NumberReferenceFrames": 3,
+        "FramerateDenominator": 1001,
+        "QvbrSettings": {
+          "QvbrQualityLevel": 7
+        },
+        "MaxBitrate": 3500000,
+        "RateControlMode": "QVBR",
+        "GopBReference": "ENABLED",
+        "EntropyEncoding": "CABAC",
+        "GopSizeUnits": "FRAMES",
+        "FlickerAdaptiveQuantization": "ENABLED",
+        "Telecine": "NONE",
+        "ParDenominator": 1,
+        "AdaptiveQuantization": "HIGH",
+        "InterlaceMode": "PROGRESSIVE",
+        "QualityTuningLevel": "SINGLE_PASS_HQ",
+        "HrdBufferInitialFillPercentage": 90,
+        "RepeatPps": "DISABLED",
+        "FieldEncoding": "PAFF",
+        "SlowPal": "DISABLED",
+        "GopClosedCadence": 1,
+        "GopSize": 90.0,
+        "ParControl": "SPECIFIED",
+        "Slices": 1,
+        "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+        "ParNumerator": 1,
+        "SceneChangeDetect": "ENABLED",
+        "CodecLevel": "LEVEL_4",
+        "NumberBFramesBetweenReferenceFrames": 3,
+        "HrdBufferSize": 7000000
+      }
     },
-    "ContainerSettings": {
-      "Container": "MPD"
-    }
+    "DropFrameTimecode": "ENABLED",
+    "VideoPreprocessors": {
+      "Deinterlacer": {
+        "Control": "NORMAL",
+        "Mode": "DEINTERLACE",
+        "Algorithm": "INTERPOLATE"
+      }
+    },
+    "RespondToAfd": "NONE",
+    "Sharpness": 50,
+    "AfdSignaling": "NONE",
+    "Height": 1280,
+    "Width": 720,
+    "ScalingBehavior": "DEFAULT",
+    "ColorMetadata": "INSERT",
+    "AntiAlias": "ENABLED",
+    "TimecodeInsertion": "DISABLED"
+  },
+  "ContainerSettings": {
+    "Container": "MPD"
   }
 }

--- a/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_5.0Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_5.0Mbps_qvbr.json
@@ -1,0 +1,72 @@
+{
+  "Description": "video on demand on aws",
+  "Category": "VOD",
+  "Name": "_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_5.0Mbps_qvbr",
+  "Settings": {
+    "VideoDescription": {
+      "Width": 720,
+      "ScalingBehavior": "DEFAULT",
+      "Height": 1280,
+      "VideoPreprocessors": {
+        "Deinterlacer": {
+          "Algorithm": "INTERPOLATE",
+          "Mode": "DEINTERLACE",
+          "Control": "NORMAL"
+        }
+      },
+      "TimecodeInsertion": "DISABLED",
+      "AntiAlias": "ENABLED",
+      "Sharpness": 50,
+      "CodecSettings": {
+        "Codec": "H_264",
+        "H264Settings": {
+          "InterlaceMode": "PROGRESSIVE",
+          "ParNumerator": 1,
+          "NumberReferenceFrames": 3,
+          "Syntax": "DEFAULT",
+          "FramerateDenominator": 1001,
+          "GopClosedCadence": 1,
+          "HrdBufferInitialFillPercentage": 90,
+          "GopSize": 90,
+          "Slices": 1,
+          "GopBReference": "ENABLED",
+          "HrdBufferSize": 10000000,
+          "MaxBitrate": 5000000,
+          "SlowPal": "DISABLED",
+          "ParDenominator": 1,
+          "SpatialAdaptiveQuantization": "ENABLED",
+          "TemporalAdaptiveQuantization": "ENABLED",
+          "FlickerAdaptiveQuantization": "ENABLED",
+          "EntropyEncoding": "CABAC",
+          "FramerateControl": "SPECIFIED",
+          "RateControlMode": "QVBR",
+          "QvbrSettings": {
+            "QvbrQualityLevel": 8
+          },
+          "CodecProfile": "HIGH",
+          "Telecine": "NONE",
+          "FramerateNumerator": 30000,
+          "MinIInterval": 0,
+          "AdaptiveQuantization": "HIGH",
+          "CodecLevel": "LEVEL_4",
+          "FieldEncoding": "PAFF",
+          "SceneChangeDetect": "ENABLED",
+          "QualityTuningLevel": "SINGLE_PASS_HQ",
+          "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+          "UnregisteredSeiTimecode": "DISABLED",
+          "GopSizeUnits": "FRAMES",
+          "ParControl": "SPECIFIED",
+          "NumberBFramesBetweenReferenceFrames": 3,
+          "RepeatPps": "DISABLED"
+        }
+      },
+      "AfdSignaling": "NONE",
+      "DropFrameTimecode": "ENABLED",
+      "RespondToAfd": "NONE",
+      "ColorMetadata": "INSERT"
+    },
+    "ContainerSettings": {
+      "Container": "MPD"
+    }
+  }
+}

--- a/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_5.0Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_5.0Mbps_qvbr.json
@@ -1,72 +1,67 @@
 {
-  "Description": "video on demand on aws",
-  "Category": "VOD",
-  "Name": "_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_5.0Mbps_qvbr",
-  "Settings": {
-    "VideoDescription": {
-      "Width": 720,
-      "ScalingBehavior": "DEFAULT",
-      "Height": 1280,
-      "VideoPreprocessors": {
-        "Deinterlacer": {
-          "Algorithm": "INTERPOLATE",
-          "Mode": "DEINTERLACE",
-          "Control": "NORMAL"
-        }
-      },
-      "TimecodeInsertion": "DISABLED",
-      "AntiAlias": "ENABLED",
-      "Sharpness": 50,
-      "CodecSettings": {
-        "Codec": "H_264",
-        "H264Settings": {
-          "InterlaceMode": "PROGRESSIVE",
-          "ParNumerator": 1,
-          "NumberReferenceFrames": 3,
-          "Syntax": "DEFAULT",
-          "FramerateDenominator": 1001,
-          "GopClosedCadence": 1,
-          "HrdBufferInitialFillPercentage": 90,
-          "GopSize": 90,
-          "Slices": 1,
-          "GopBReference": "ENABLED",
-          "HrdBufferSize": 10000000,
-          "MaxBitrate": 5000000,
-          "SlowPal": "DISABLED",
-          "ParDenominator": 1,
-          "SpatialAdaptiveQuantization": "ENABLED",
-          "TemporalAdaptiveQuantization": "ENABLED",
-          "FlickerAdaptiveQuantization": "ENABLED",
-          "EntropyEncoding": "CABAC",
-          "FramerateControl": "SPECIFIED",
-          "RateControlMode": "QVBR",
-          "QvbrSettings": {
-            "QvbrQualityLevel": 8
-          },
-          "CodecProfile": "HIGH",
-          "Telecine": "NONE",
-          "FramerateNumerator": 30000,
-          "MinIInterval": 0,
-          "AdaptiveQuantization": "HIGH",
-          "CodecLevel": "LEVEL_4",
-          "FieldEncoding": "PAFF",
-          "SceneChangeDetect": "ENABLED",
-          "QualityTuningLevel": "SINGLE_PASS_HQ",
-          "FramerateConversionAlgorithm": "DUPLICATE_DROP",
-          "UnregisteredSeiTimecode": "DISABLED",
-          "GopSizeUnits": "FRAMES",
-          "ParControl": "SPECIFIED",
-          "NumberBFramesBetweenReferenceFrames": 3,
-          "RepeatPps": "DISABLED"
-        }
-      },
-      "AfdSignaling": "NONE",
-      "DropFrameTimecode": "ENABLED",
-      "RespondToAfd": "NONE",
-      "ColorMetadata": "INSERT"
+  "VideoDescription": {
+    "CodecSettings": {
+      "Codec": "H_264",
+      "H264Settings": {
+        "CodecProfile": "HIGH",
+        "SpatialAdaptiveQuantization": "ENABLED",
+        "TemporalAdaptiveQuantization": "ENABLED",
+        "Syntax": "DEFAULT",
+        "FramerateNumerator": 30000,
+        "MinIInterval": 0,
+        "UnregisteredSeiTimecode": "DISABLED",
+        "FramerateControl": "SPECIFIED",
+        "NumberReferenceFrames": 3,
+        "FramerateDenominator": 1001,
+        "QvbrSettings": {
+          "QvbrQualityLevel": 8
+        },
+        "MaxBitrate": 5000000,
+        "RateControlMode": "QVBR",
+        "GopBReference": "ENABLED",
+        "EntropyEncoding": "CABAC",
+        "GopSizeUnits": "FRAMES",
+        "FlickerAdaptiveQuantization": "ENABLED",
+        "Telecine": "NONE",
+        "ParDenominator": 1,
+        "AdaptiveQuantization": "HIGH",
+        "InterlaceMode": "PROGRESSIVE",
+        "QualityTuningLevel": "SINGLE_PASS_HQ",
+        "HrdBufferInitialFillPercentage": 90,
+        "RepeatPps": "DISABLED",
+        "FieldEncoding": "PAFF",
+        "SlowPal": "DISABLED",
+        "GopClosedCadence": 1,
+        "GopSize": 90.0,
+        "ParControl": "SPECIFIED",
+        "Slices": 1,
+        "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+        "ParNumerator": 1,
+        "SceneChangeDetect": "ENABLED",
+        "CodecLevel": "LEVEL_4",
+        "NumberBFramesBetweenReferenceFrames": 3,
+        "HrdBufferSize": 10000000
+      }
     },
-    "ContainerSettings": {
-      "Container": "MPD"
-    }
+    "DropFrameTimecode": "ENABLED",
+    "VideoPreprocessors": {
+      "Deinterlacer": {
+        "Control": "NORMAL",
+        "Mode": "DEINTERLACE",
+        "Algorithm": "INTERPOLATE"
+      }
+    },
+    "RespondToAfd": "NONE",
+    "Sharpness": 50,
+    "AfdSignaling": "NONE",
+    "Height": 1280,
+    "Width": 720,
+    "ScalingBehavior": "DEFAULT",
+    "ColorMetadata": "INSERT",
+    "AntiAlias": "ENABLED",
+    "TimecodeInsertion": "DISABLED"
+  },
+  "ContainerSettings": {
+    "Container": "MPD"
   }
 }

--- a/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_6.5Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_6.5Mbps_qvbr.json
@@ -1,0 +1,67 @@
+{
+  "VideoDescription": {
+    "CodecSettings": {
+      "Codec": "H_264",
+      "H264Settings": {
+        "CodecProfile": "HIGH",
+        "SpatialAdaptiveQuantization": "ENABLED",
+        "TemporalAdaptiveQuantization": "ENABLED",
+        "Syntax": "DEFAULT",
+        "FramerateNumerator": 30000,
+        "MinIInterval": 0,
+        "UnregisteredSeiTimecode": "DISABLED",
+        "FramerateControl": "SPECIFIED",
+        "NumberReferenceFrames": 3,
+        "FramerateDenominator": 1001,
+        "QvbrSettings": {
+          "QvbrQualityLevel": 8
+        },
+        "MaxBitrate": 6500000,
+        "RateControlMode": "QVBR",
+        "GopBReference": "ENABLED",
+        "EntropyEncoding": "CABAC",
+        "GopSizeUnits": "FRAMES",
+        "FlickerAdaptiveQuantization": "ENABLED",
+        "Telecine": "NONE",
+        "ParDenominator": 1,
+        "AdaptiveQuantization": "HIGH",
+        "InterlaceMode": "PROGRESSIVE",
+        "QualityTuningLevel": "SINGLE_PASS_HQ",
+        "HrdBufferInitialFillPercentage": 90,
+        "RepeatPps": "DISABLED",
+        "FieldEncoding": "PAFF",
+        "SlowPal": "DISABLED",
+        "GopClosedCadence": 1,
+        "GopSize": 90.0,
+        "ParControl": "SPECIFIED",
+        "Slices": 1,
+        "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+        "ParNumerator": 1,
+        "SceneChangeDetect": "ENABLED",
+        "CodecLevel": "LEVEL_4",
+        "NumberBFramesBetweenReferenceFrames": 3,
+        "HrdBufferSize": 13000000
+      }
+    },
+    "DropFrameTimecode": "ENABLED",
+    "VideoPreprocessors": {
+      "Deinterlacer": {
+        "Control": "NORMAL",
+        "Mode": "DEINTERLACE",
+        "Algorithm": "INTERPOLATE"
+      }
+    },
+    "RespondToAfd": "NONE",
+    "Sharpness": 50,
+    "AfdSignaling": "NONE",
+    "Height": 1280,
+    "Width": 720,
+    "ScalingBehavior": "DEFAULT",
+    "ColorMetadata": "INSERT",
+    "AntiAlias": "ENABLED",
+    "TimecodeInsertion": "DISABLED"
+  },
+  "ContainerSettings": {
+    "Container": "MPD"
+  }
+}

--- a/source/custom-resource/lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_9x16_1080x1920p_30Hz_8.5Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_9x16_1080x1920p_30Hz_8.5Mbps_qvbr.json
@@ -1,0 +1,115 @@
+{
+  "VideoDescription": {
+    "CodecSettings": {
+      "Codec": "H_264",
+      "H264Settings": {
+        "CodecProfile": "HIGH",
+        "SpatialAdaptiveQuantization": "ENABLED",
+        "TemporalAdaptiveQuantization": "ENABLED",
+        "Syntax": "DEFAULT",
+        "FramerateNumerator": 30000,
+        "MinIInterval": 0,
+        "UnregisteredSeiTimecode": "DISABLED",
+        "FramerateControl": "SPECIFIED",
+        "NumberReferenceFrames": 3,
+        "FramerateDenominator": 1001,
+        "QvbrSettings": {
+          "QvbrQualityLevel": 8
+        },
+        "MaxBitrate": 8500000,
+        "RateControlMode": "QVBR",
+        "GopBReference": "DISABLED",
+        "EntropyEncoding": "CABAC",
+        "GopSizeUnits": "FRAMES",
+        "FlickerAdaptiveQuantization": "ENABLED",
+        "Telecine": "NONE",
+        "ParDenominator": 1,
+        "AdaptiveQuantization": "HIGH",
+        "InterlaceMode": "PROGRESSIVE",
+        "QualityTuningLevel": "SINGLE_PASS_HQ",
+        "HrdBufferInitialFillPercentage": 90,
+        "RepeatPps": "DISABLED",
+        "FieldEncoding": "PAFF",
+        "SlowPal": "DISABLED",
+        "GopClosedCadence": 1,
+        "GopSize": 90.0,
+        "ParControl": "SPECIFIED",
+        "Slices": 1,
+        "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+        "ParNumerator": 1,
+        "SceneChangeDetect": "ENABLED",
+        "CodecLevel": "LEVEL_4",
+        "NumberBFramesBetweenReferenceFrames": 1,
+        "HrdBufferSize": 17000000
+      }
+    },
+    "DropFrameTimecode": "ENABLED",
+    "VideoPreprocessors": {
+      "Deinterlacer": {
+        "Control": "NORMAL",
+        "Mode": "DEINTERLACE",
+        "Algorithm": "INTERPOLATE"
+      }
+    },
+    "RespondToAfd": "NONE",
+    "Sharpness": 50,
+    "AfdSignaling": "NONE",
+    "Height": 1920,
+    "Width": 1080,
+    "ScalingBehavior": "DEFAULT",
+    "ColorMetadata": "INSERT",
+    "AntiAlias": "ENABLED",
+    "TimecodeInsertion": "DISABLED"
+  },
+  "AudioDescriptions": [{
+    "CodecSettings": {
+      "Codec": "AAC",
+      "AacSettings": {
+        "CodecProfile": "LC",
+        "Specification": "MPEG4",
+        "RateControlMode": "CBR",
+        "AudioDescriptionBroadcasterMix": "NORMAL",
+        "SampleRate": 48000,
+        "Bitrate": 128000,
+        "CodingMode": "CODING_MODE_2_0",
+        "RawFormat": "NONE"
+      }
+    },
+    "AudioSourceName": "Audio Selector 1",
+    "AudioTypeControl": "FOLLOW_INPUT",
+    "LanguageCodeControl": "FOLLOW_INPUT",
+    "AudioType": 0
+  }],
+  "ContainerSettings": {
+    "M3u8Settings": {
+      "PatInterval": 0,
+      "PcrControl": "PCR_EVERY_PES_PACKET",
+      "PrivateMetadataPid": 503,
+      "VideoPid": 481,
+      "ProgramNumber": 1,
+      "PmtPid": 480,
+      "PmtInterval": 0,
+      "AudioPids": [
+        482,
+        483,
+        484,
+        485,
+        486,
+        487,
+        488,
+        489,
+        490,
+        491,
+        492,
+        493,
+        494,
+        495,
+        496,
+        497,
+        498
+      ],
+      "AudioFramesPerPes": 4
+    },
+    "Container": "M3U8"
+  }
+}

--- a/source/custom-resource/lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_9x16_270x480p_15Hz_0.4Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_9x16_270x480p_15Hz_0.4Mbps_qvbr.json
@@ -1,0 +1,115 @@
+{
+  "VideoDescription": {
+    "CodecSettings": {
+      "Codec": "H_264",
+      "H264Settings": {
+        "CodecProfile": "MAIN",
+        "SpatialAdaptiveQuantization": "ENABLED",
+        "TemporalAdaptiveQuantization": "ENABLED",
+        "Syntax": "DEFAULT",
+        "FramerateNumerator": 15000,
+        "MinIInterval": 0,
+        "UnregisteredSeiTimecode": "DISABLED",
+        "FramerateControl": "SPECIFIED",
+        "NumberReferenceFrames": 3,
+        "FramerateDenominator": 1001,
+        "QvbrSettings": {
+          "QvbrQualityLevel": 7
+        },
+        "MaxBitrate": 400000,
+        "RateControlMode": "QVBR",
+        "GopBReference": "ENABLED",
+        "EntropyEncoding": "CABAC",
+        "GopSizeUnits": "FRAMES",
+        "FlickerAdaptiveQuantization": "ENABLED",
+        "Telecine": "NONE",
+        "ParDenominator": 1,
+        "AdaptiveQuantization": "MEDIUM",
+        "InterlaceMode": "PROGRESSIVE",
+        "QualityTuningLevel": "SINGLE_PASS_HQ",
+        "HrdBufferInitialFillPercentage": 90,
+        "RepeatPps": "DISABLED",
+        "FieldEncoding": "PAFF",
+        "SlowPal": "DISABLED",
+        "GopClosedCadence": 1,
+        "GopSize": 45.0,
+        "ParControl": "SPECIFIED",
+        "Slices": 1,
+        "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+        "ParNumerator": 1,
+        "SceneChangeDetect": "ENABLED",
+        "CodecLevel": "LEVEL_3_1",
+        "NumberBFramesBetweenReferenceFrames": 3,
+        "HrdBufferSize": 800000
+      }
+    },
+    "DropFrameTimecode": "ENABLED",
+    "VideoPreprocessors": {
+      "Deinterlacer": {
+        "Control": "NORMAL",
+        "Mode": "DEINTERLACE",
+        "Algorithm": "INTERPOLATE"
+      }
+    },
+    "RespondToAfd": "NONE",
+    "Sharpness": 50,
+    "AfdSignaling": "NONE",
+    "Height": 480,
+    "Width": 270,
+    "ScalingBehavior": "DEFAULT",
+    "ColorMetadata": "INSERT",
+    "AntiAlias": "ENABLED",
+    "TimecodeInsertion": "DISABLED"
+  },
+  "AudioDescriptions": [{
+    "CodecSettings": {
+      "Codec": "AAC",
+      "AacSettings": {
+        "CodecProfile": "HEV1",
+        "Specification": "MPEG4",
+        "RateControlMode": "CBR",
+        "AudioDescriptionBroadcasterMix": "NORMAL",
+        "SampleRate": 48000,
+        "Bitrate": 64000,
+        "CodingMode": "CODING_MODE_2_0",
+        "RawFormat": "NONE"
+      }
+    },
+    "AudioSourceName": "Audio Selector 1",
+    "AudioTypeControl": "FOLLOW_INPUT",
+    "LanguageCodeControl": "FOLLOW_INPUT",
+    "AudioType": 0
+  }],
+  "ContainerSettings": {
+    "M3u8Settings": {
+      "PatInterval": 0,
+      "PcrControl": "PCR_EVERY_PES_PACKET",
+      "PrivateMetadataPid": 503,
+      "VideoPid": 481,
+      "ProgramNumber": 1,
+      "PmtPid": 480,
+      "PmtInterval": 0,
+      "AudioPids": [
+        482,
+        483,
+        484,
+        485,
+        486,
+        487,
+        488,
+        489,
+        490,
+        491,
+        492,
+        493,
+        494,
+        495,
+        496,
+        497,
+        498
+      ],
+      "AudioFramesPerPes": 4
+    },
+    "Container": "M3U8"
+  }
+}

--- a/source/custom-resource/lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_9x16_360x640p_30Hz_0.6Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_9x16_360x640p_30Hz_0.6Mbps_qvbr.json
@@ -1,0 +1,115 @@
+ {
+   "VideoDescription": {
+     "CodecSettings": {
+       "Codec": "H_264",
+       "H264Settings": {
+         "CodecProfile": "MAIN",
+         "SpatialAdaptiveQuantization": "ENABLED",
+         "TemporalAdaptiveQuantization": "ENABLED",
+         "Syntax": "DEFAULT",
+         "FramerateNumerator": 30000,
+         "MinIInterval": 0,
+         "UnregisteredSeiTimecode": "DISABLED",
+         "FramerateControl": "SPECIFIED",
+         "NumberReferenceFrames": 3,
+         "FramerateDenominator": 1001,
+         "QvbrSettings": {
+           "QvbrQualityLevel": 7
+         },
+         "MaxBitrate": 600000,
+         "RateControlMode": "QVBR",
+         "GopBReference": "ENABLED",
+         "EntropyEncoding": "CABAC",
+         "GopSizeUnits": "FRAMES",
+         "FlickerAdaptiveQuantization": "ENABLED",
+         "Telecine": "NONE",
+         "ParDenominator": 1,
+         "AdaptiveQuantization": "MEDIUM",
+         "InterlaceMode": "PROGRESSIVE",
+         "QualityTuningLevel": "SINGLE_PASS_HQ",
+         "HrdBufferInitialFillPercentage": 90,
+         "RepeatPps": "DISABLED",
+         "FieldEncoding": "PAFF",
+         "SlowPal": "DISABLED",
+         "GopClosedCadence": 1,
+         "GopSize": 90.0,
+         "ParControl": "SPECIFIED",
+         "Slices": 1,
+         "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+         "ParNumerator": 1,
+         "SceneChangeDetect": "ENABLED",
+         "CodecLevel": "LEVEL_3_1",
+         "NumberBFramesBetweenReferenceFrames": 3,
+         "HrdBufferSize": 1200000
+       }
+     },
+     "DropFrameTimecode": "ENABLED",
+     "VideoPreprocessors": {
+       "Deinterlacer": {
+         "Control": "NORMAL",
+         "Mode": "DEINTERLACE",
+         "Algorithm": "INTERPOLATE"
+       }
+     },
+     "RespondToAfd": "NONE",
+     "Sharpness": 50,
+     "AfdSignaling": "NONE",
+     "Height": 640,
+     "Width": 360,
+     "ScalingBehavior": "DEFAULT",
+     "ColorMetadata": "INSERT",
+     "AntiAlias": "ENABLED",
+     "TimecodeInsertion": "DISABLED"
+   },
+   "AudioDescriptions": [{
+     "CodecSettings": {
+       "Codec": "AAC",
+       "AacSettings": {
+         "CodecProfile": "HEV1",
+         "Specification": "MPEG4",
+         "RateControlMode": "CBR",
+         "AudioDescriptionBroadcasterMix": "NORMAL",
+         "SampleRate": 48000,
+         "Bitrate": 64000,
+         "CodingMode": "CODING_MODE_2_0",
+         "RawFormat": "NONE"
+       }
+     },
+     "AudioSourceName": "Audio Selector 1",
+     "AudioTypeControl": "FOLLOW_INPUT",
+     "LanguageCodeControl": "FOLLOW_INPUT",
+     "AudioType": 0
+   }],
+   "ContainerSettings": {
+     "M3u8Settings": {
+       "PatInterval": 0,
+       "PcrControl": "PCR_EVERY_PES_PACKET",
+       "PrivateMetadataPid": 503,
+       "VideoPid": 481,
+       "ProgramNumber": 1,
+       "PmtPid": 480,
+       "PmtInterval": 0,
+       "AudioPids": [
+         482,
+         483,
+         484,
+         485,
+         486,
+         487,
+         488,
+         489,
+         490,
+         491,
+         492,
+         493,
+         494,
+         495,
+         496,
+         497,
+         498
+       ],
+       "AudioFramesPerPes": 4
+     },
+     "Container": "M3U8"
+   }
+ }

--- a/source/custom-resource/lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_9x16_360x640p_30Hz_1.2Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_9x16_360x640p_30Hz_1.2Mbps_qvbr.json
@@ -1,0 +1,115 @@
+{
+  "VideoDescription": {
+    "CodecSettings": {
+      "Codec": "H_264",
+      "H264Settings": {
+        "CodecProfile": "MAIN",
+        "SpatialAdaptiveQuantization": "ENABLED",
+        "TemporalAdaptiveQuantization": "ENABLED",
+        "Syntax": "DEFAULT",
+        "FramerateNumerator": 30000,
+        "MinIInterval": 0,
+        "UnregisteredSeiTimecode": "DISABLED",
+        "FramerateControl": "SPECIFIED",
+        "NumberReferenceFrames": 3,
+        "FramerateDenominator": 1001,
+        "QvbrSettings": {
+          "QvbrQualityLevel": 7
+        },
+        "MaxBitrate": 1200000,
+        "RateControlMode": "QVBR",
+        "GopBReference": "ENABLED",
+        "EntropyEncoding": "CABAC",
+        "GopSizeUnits": "FRAMES",
+        "FlickerAdaptiveQuantization": "ENABLED",
+        "Telecine": "NONE",
+        "ParDenominator": 1,
+        "AdaptiveQuantization": "MEDIUM",
+        "InterlaceMode": "PROGRESSIVE",
+        "QualityTuningLevel": "SINGLE_PASS_HQ",
+        "HrdBufferInitialFillPercentage": 90,
+        "RepeatPps": "DISABLED",
+        "FieldEncoding": "PAFF",
+        "SlowPal": "DISABLED",
+        "GopClosedCadence": 1,
+        "GopSize": 90.0,
+        "ParControl": "SPECIFIED",
+        "Slices": 1,
+        "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+        "ParNumerator": 1,
+        "SceneChangeDetect": "ENABLED",
+        "CodecLevel": "LEVEL_3_1",
+        "NumberBFramesBetweenReferenceFrames": 3,
+        "HrdBufferSize": 2400000
+      }
+    },
+    "DropFrameTimecode": "ENABLED",
+    "VideoPreprocessors": {
+      "Deinterlacer": {
+        "Control": "NORMAL",
+        "Mode": "DEINTERLACE",
+        "Algorithm": "INTERPOLATE"
+      }
+    },
+    "RespondToAfd": "NONE",
+    "Sharpness": 50,
+    "AfdSignaling": "NONE",
+    "Height": 640,
+    "Width": 360,
+    "ScalingBehavior": "DEFAULT",
+    "ColorMetadata": "INSERT",
+    "AntiAlias": "ENABLED",
+    "TimecodeInsertion": "DISABLED"
+  },
+  "AudioDescriptions": [{
+    "CodecSettings": {
+      "Codec": "AAC",
+      "AacSettings": {
+        "CodecProfile": "HEV1",
+        "Specification": "MPEG4",
+        "RateControlMode": "CBR",
+        "AudioDescriptionBroadcasterMix": "NORMAL",
+        "SampleRate": 48000,
+        "Bitrate": 96000,
+        "CodingMode": "CODING_MODE_2_0",
+        "RawFormat": "NONE"
+      }
+    },
+    "AudioSourceName": "Audio Selector 1",
+    "AudioTypeControl": "FOLLOW_INPUT",
+    "LanguageCodeControl": "FOLLOW_INPUT",
+    "AudioType": 0
+  }],
+  "ContainerSettings": {
+    "M3u8Settings": {
+      "PatInterval": 0,
+      "PcrControl": "PCR_EVERY_PES_PACKET",
+      "PrivateMetadataPid": 503,
+      "VideoPid": 481,
+      "ProgramNumber": 1,
+      "PmtPid": 480,
+      "PmtInterval": 0,
+      "AudioPids": [
+        482,
+        483,
+        484,
+        485,
+        486,
+        487,
+        488,
+        489,
+        490,
+        491,
+        492,
+        493,
+        494,
+        495,
+        496,
+        497,
+        498
+      ],
+      "AudioFramesPerPes": 4
+    },
+    "Container": "M3U8"
+  }
+}

--- a/source/custom-resource/lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_9x16_540x960p_30Hz_3.5Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_9x16_540x960p_30Hz_3.5Mbps_qvbr.json
@@ -1,0 +1,115 @@
+{
+  "VideoDescription": {
+    "CodecSettings": {
+      "Codec": "H_264",
+      "H264Settings": {
+        "CodecProfile": "HIGH",
+        "SpatialAdaptiveQuantization": "ENABLED",
+        "TemporalAdaptiveQuantization": "ENABLED",
+        "Syntax": "DEFAULT",
+        "FramerateNumerator": 30000,
+        "MinIInterval": 0,
+        "UnregisteredSeiTimecode": "DISABLED",
+        "FramerateControl": "SPECIFIED",
+        "NumberReferenceFrames": 3,
+        "FramerateDenominator": 1001,
+        "QvbrSettings": {
+          "QvbrQualityLevel": 7
+        },
+        "MaxBitrate": 3500000,
+        "RateControlMode": "QVBR",
+        "GopBReference": "ENABLED",
+        "EntropyEncoding": "CABAC",
+        "GopSizeUnits": "FRAMES",
+        "FlickerAdaptiveQuantization": "ENABLED",
+        "Telecine": "NONE",
+        "ParDenominator": 1,
+        "AdaptiveQuantization": "HIGH",
+        "InterlaceMode": "PROGRESSIVE",
+        "QualityTuningLevel": "SINGLE_PASS_HQ",
+        "HrdBufferInitialFillPercentage": 90,
+        "RepeatPps": "DISABLED",
+        "FieldEncoding": "PAFF",
+        "SlowPal": "DISABLED",
+        "GopClosedCadence": 1,
+        "GopSize": 90.0,
+        "ParControl": "SPECIFIED",
+        "Slices": 1,
+        "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+        "ParNumerator": 1,
+        "SceneChangeDetect": "ENABLED",
+        "CodecLevel": "LEVEL_4",
+        "NumberBFramesBetweenReferenceFrames": 3,
+        "HrdBufferSize": 7000000
+      }
+    },
+    "DropFrameTimecode": "ENABLED",
+    "VideoPreprocessors": {
+      "Deinterlacer": {
+        "Control": "NORMAL",
+        "Mode": "DEINTERLACE",
+        "Algorithm": "INTERPOLATE"
+      }
+    },
+    "RespondToAfd": "NONE",
+    "Sharpness": 50,
+    "AfdSignaling": "NONE",
+    "Height": 960,
+    "Width": 540,
+    "ScalingBehavior": "DEFAULT",
+    "ColorMetadata": "INSERT",
+    "AntiAlias": "ENABLED",
+    "TimecodeInsertion": "DISABLED"
+  },
+  "AudioDescriptions": [{
+    "CodecSettings": {
+      "Codec": "AAC",
+      "AacSettings": {
+        "CodecProfile": "HEV1",
+        "Specification": "MPEG4",
+        "RateControlMode": "CBR",
+        "AudioDescriptionBroadcasterMix": "NORMAL",
+        "SampleRate": 48000,
+        "Bitrate": 96000,
+        "CodingMode": "CODING_MODE_2_0",
+        "RawFormat": "NONE"
+      }
+    },
+    "AudioSourceName": "Audio Selector 1",
+    "AudioTypeControl": "FOLLOW_INPUT",
+    "LanguageCodeControl": "FOLLOW_INPUT",
+    "AudioType": 0
+  }],
+  "ContainerSettings": {
+    "M3u8Settings": {
+      "PatInterval": 0,
+      "PcrControl": "PCR_EVERY_PES_PACKET",
+      "PrivateMetadataPid": 503,
+      "VideoPid": 481,
+      "ProgramNumber": 1,
+      "PmtPid": 480,
+      "PmtInterval": 0,
+      "AudioPids": [
+        482,
+        483,
+        484,
+        485,
+        486,
+        487,
+        488,
+        489,
+        490,
+        491,
+        492,
+        493,
+        494,
+        495,
+        496,
+        497,
+        498
+      ],
+      "AudioFramesPerPes": 4
+    },
+    "Container": "M3U8"
+  }
+}

--- a/source/custom-resource/lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_3.5Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_3.5Mbps_qvbr.json
@@ -1,0 +1,115 @@
+{
+  "VideoDescription": {
+    "CodecSettings": {
+      "Codec": "H_264",
+      "H264Settings": {
+        "CodecProfile": "HIGH",
+        "SpatialAdaptiveQuantization": "ENABLED",
+        "TemporalAdaptiveQuantization": "ENABLED",
+        "Syntax": "DEFAULT",
+        "FramerateNumerator": 30000,
+        "MinIInterval": 0,
+        "UnregisteredSeiTimecode": "DISABLED",
+        "FramerateControl": "SPECIFIED",
+        "NumberReferenceFrames": 3,
+        "FramerateDenominator": 1001,
+        "QvbrSettings": {
+          "QvbrQualityLevel": 7
+        },
+        "MaxBitrate": 3500000,
+        "RateControlMode": "QVBR",
+        "GopBReference": "ENABLED",
+        "EntropyEncoding": "CABAC",
+        "GopSizeUnits": "FRAMES",
+        "FlickerAdaptiveQuantization": "ENABLED",
+        "Telecine": "NONE",
+        "ParDenominator": 1,
+        "AdaptiveQuantization": "HIGH",
+        "InterlaceMode": "PROGRESSIVE",
+        "QualityTuningLevel": "SINGLE_PASS_HQ",
+        "HrdBufferInitialFillPercentage": 90,
+        "RepeatPps": "DISABLED",
+        "FieldEncoding": "PAFF",
+        "SlowPal": "DISABLED",
+        "GopClosedCadence": 1,
+        "GopSize": 90.0,
+        "ParControl": "SPECIFIED",
+        "Slices": 1,
+        "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+        "ParNumerator": 1,
+        "SceneChangeDetect": "ENABLED",
+        "CodecLevel": "LEVEL_4",
+        "NumberBFramesBetweenReferenceFrames": 3,
+        "HrdBufferSize": 7000000
+      }
+    },
+    "DropFrameTimecode": "ENABLED",
+    "VideoPreprocessors": {
+      "Deinterlacer": {
+        "Control": "NORMAL",
+        "Mode": "DEINTERLACE",
+        "Algorithm": "INTERPOLATE"
+      }
+    },
+    "RespondToAfd": "NONE",
+    "Sharpness": 50,
+    "AfdSignaling": "NONE",
+    "Height": 1280,
+    "Width": 720,
+    "ScalingBehavior": "DEFAULT",
+    "ColorMetadata": "INSERT",
+    "AntiAlias": "ENABLED",
+    "TimecodeInsertion": "DISABLED"
+  },
+  "AudioDescriptions": [{
+    "CodecSettings": {
+      "Codec": "AAC",
+      "AacSettings": {
+        "CodecProfile": "HEV1",
+        "Specification": "MPEG4",
+        "RateControlMode": "CBR",
+        "AudioDescriptionBroadcasterMix": "NORMAL",
+        "SampleRate": 48000,
+        "Bitrate": 96000,
+        "CodingMode": "CODING_MODE_2_0",
+        "RawFormat": "NONE"
+      }
+    },
+    "AudioSourceName": "Audio Selector 1",
+    "AudioTypeControl": "FOLLOW_INPUT",
+    "LanguageCodeControl": "FOLLOW_INPUT",
+    "AudioType": 0
+  }],
+  "ContainerSettings": {
+    "M3u8Settings": {
+      "PatInterval": 0,
+      "PcrControl": "PCR_EVERY_PES_PACKET",
+      "PrivateMetadataPid": 503,
+      "VideoPid": 481,
+      "ProgramNumber": 1,
+      "PmtPid": 480,
+      "PmtInterval": 0,
+      "AudioPids": [
+        482,
+        483,
+        484,
+        485,
+        486,
+        487,
+        488,
+        489,
+        490,
+        491,
+        492,
+        493,
+        494,
+        495,
+        496,
+        497,
+        498
+      ],
+      "AudioFramesPerPes": 4
+    },
+    "Container": "M3U8"
+  }
+}

--- a/source/custom-resource/lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_5.0Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_5.0Mbps_qvbr.json
@@ -1,0 +1,115 @@
+{
+  "VideoDescription": {
+    "CodecSettings": {
+      "Codec": "H_264",
+      "H264Settings": {
+        "CodecProfile": "HIGH",
+        "SpatialAdaptiveQuantization": "ENABLED",
+        "TemporalAdaptiveQuantization": "ENABLED",
+        "Syntax": "DEFAULT",
+        "FramerateNumerator": 30000,
+        "MinIInterval": 0,
+        "UnregisteredSeiTimecode": "DISABLED",
+        "FramerateControl": "SPECIFIED",
+        "NumberReferenceFrames": 3,
+        "FramerateDenominator": 1001,
+        "QvbrSettings": {
+          "QvbrQualityLevel": 8
+        },
+        "MaxBitrate": 5000000,
+        "RateControlMode": "QVBR",
+        "GopBReference": "ENABLED",
+        "EntropyEncoding": "CABAC",
+        "GopSizeUnits": "FRAMES",
+        "FlickerAdaptiveQuantization": "ENABLED",
+        "Telecine": "NONE",
+        "ParDenominator": 1,
+        "AdaptiveQuantization": "HIGH",
+        "InterlaceMode": "PROGRESSIVE",
+        "QualityTuningLevel": "SINGLE_PASS_HQ",
+        "HrdBufferInitialFillPercentage": 90,
+        "RepeatPps": "DISABLED",
+        "FieldEncoding": "PAFF",
+        "SlowPal": "DISABLED",
+        "GopClosedCadence": 1,
+        "GopSize": 90.0,
+        "ParControl": "SPECIFIED",
+        "Slices": 1,
+        "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+        "ParNumerator": 1,
+        "SceneChangeDetect": "ENABLED",
+        "CodecLevel": "LEVEL_4",
+        "NumberBFramesBetweenReferenceFrames": 3,
+        "HrdBufferSize": 10000000
+      }
+    },
+    "DropFrameTimecode": "ENABLED",
+    "VideoPreprocessors": {
+      "Deinterlacer": {
+        "Control": "NORMAL",
+        "Mode": "DEINTERLACE",
+        "Algorithm": "INTERPOLATE"
+      }
+    },
+    "RespondToAfd": "NONE",
+    "Sharpness": 50,
+    "AfdSignaling": "NONE",
+    "Height": 1280,
+    "Width": 720,
+    "ScalingBehavior": "DEFAULT",
+    "ColorMetadata": "INSERT",
+    "AntiAlias": "ENABLED",
+    "TimecodeInsertion": "DISABLED"
+  },
+  "AudioDescriptions": [{
+    "CodecSettings": {
+      "Codec": "AAC",
+      "AacSettings": {
+        "CodecProfile": "HEV1",
+        "Specification": "MPEG4",
+        "RateControlMode": "CBR",
+        "AudioDescriptionBroadcasterMix": "NORMAL",
+        "SampleRate": 48000,
+        "Bitrate": 96000,
+        "CodingMode": "CODING_MODE_2_0",
+        "RawFormat": "NONE"
+      }
+    },
+    "AudioSourceName": "Audio Selector 1",
+    "AudioTypeControl": "FOLLOW_INPUT",
+    "LanguageCodeControl": "FOLLOW_INPUT",
+    "AudioType": 0
+  }],
+  "ContainerSettings": {
+    "M3u8Settings": {
+      "PatInterval": 0,
+      "PcrControl": "PCR_EVERY_PES_PACKET",
+      "PrivateMetadataPid": 503,
+      "VideoPid": 481,
+      "ProgramNumber": 1,
+      "PmtPid": 480,
+      "PmtInterval": 0,
+      "AudioPids": [
+        482,
+        483,
+        484,
+        485,
+        486,
+        487,
+        488,
+        489,
+        490,
+        491,
+        492,
+        493,
+        494,
+        495,
+        496,
+        497,
+        498
+      ],
+      "AudioFramesPerPes": 4
+    },
+    "Container": "M3U8"
+  }
+}

--- a/source/custom-resource/lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_6.5Mbps_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/presets/_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_6.5Mbps_qvbr.json
@@ -1,0 +1,115 @@
+{
+  "VideoDescription": {
+    "CodecSettings": {
+      "Codec": "H_264",
+      "H264Settings": {
+        "CodecProfile": "HIGH",
+        "SpatialAdaptiveQuantization": "ENABLED",
+        "TemporalAdaptiveQuantization": "ENABLED",
+        "Syntax": "DEFAULT",
+        "FramerateNumerator": 30000,
+        "MinIInterval": 0,
+        "UnregisteredSeiTimecode": "DISABLED",
+        "FramerateControl": "SPECIFIED",
+        "NumberReferenceFrames": 3,
+        "FramerateDenominator": 1001,
+        "QvbrSettings": {
+          "QvbrQualityLevel": 8
+        },
+        "MaxBitrate": 6500000,
+        "RateControlMode": "QVBR",
+        "GopBReference": "ENABLED",
+        "EntropyEncoding": "CABAC",
+        "GopSizeUnits": "FRAMES",
+        "FlickerAdaptiveQuantization": "ENABLED",
+        "Telecine": "NONE",
+        "ParDenominator": 1,
+        "AdaptiveQuantization": "HIGH",
+        "InterlaceMode": "PROGRESSIVE",
+        "QualityTuningLevel": "SINGLE_PASS_HQ",
+        "HrdBufferInitialFillPercentage": 90,
+        "RepeatPps": "DISABLED",
+        "FieldEncoding": "PAFF",
+        "SlowPal": "DISABLED",
+        "GopClosedCadence": 1,
+        "GopSize": 90.0,
+        "ParControl": "SPECIFIED",
+        "Slices": 1,
+        "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+        "ParNumerator": 1,
+        "SceneChangeDetect": "ENABLED",
+        "CodecLevel": "LEVEL_4",
+        "NumberBFramesBetweenReferenceFrames": 3,
+        "HrdBufferSize": 13000000
+      }
+    },
+    "DropFrameTimecode": "ENABLED",
+    "VideoPreprocessors": {
+      "Deinterlacer": {
+        "Control": "NORMAL",
+        "Mode": "DEINTERLACE",
+        "Algorithm": "INTERPOLATE"
+      }
+    },
+    "RespondToAfd": "NONE",
+    "Sharpness": 50,
+    "AfdSignaling": "NONE",
+    "Height": 1280,
+    "Width": 720,
+    "ScalingBehavior": "DEFAULT",
+    "ColorMetadata": "INSERT",
+    "AntiAlias": "ENABLED",
+    "TimecodeInsertion": "DISABLED"
+  },
+  "AudioDescriptions": [{
+    "CodecSettings": {
+      "Codec": "AAC",
+      "AacSettings": {
+        "CodecProfile": "HEV1",
+        "Specification": "MPEG4",
+        "RateControlMode": "CBR",
+        "AudioDescriptionBroadcasterMix": "NORMAL",
+        "SampleRate": 48000,
+        "Bitrate": 96000,
+        "CodingMode": "CODING_MODE_2_0",
+        "RawFormat": "NONE"
+      }
+    },
+    "AudioSourceName": "Audio Selector 1",
+    "AudioTypeControl": "FOLLOW_INPUT",
+    "LanguageCodeControl": "FOLLOW_INPUT",
+    "AudioType": 0
+  }],
+  "ContainerSettings": {
+    "M3u8Settings": {
+      "PatInterval": 0,
+      "PcrControl": "PCR_EVERY_PES_PACKET",
+      "PrivateMetadataPid": 503,
+      "VideoPid": 481,
+      "ProgramNumber": 1,
+      "PmtPid": 480,
+      "PmtInterval": 0,
+      "AudioPids": [
+        482,
+        483,
+        484,
+        485,
+        486,
+        487,
+        488,
+        489,
+        490,
+        491,
+        492,
+        493,
+        494,
+        495,
+        496,
+        497,
+        498
+      ],
+      "AudioFramesPerPes": 4
+    },
+    "Container": "M3U8"
+  }
+}

--- a/source/custom-resource/lib/mediaconvert/templates/1080p_avc_aac_9x16_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/templates/1080p_avc_aac_9x16_qvbr.json
@@ -1,0 +1,137 @@
+{
+  "Category": "VOD",
+  "Description": "video on demand on aws",
+  "Name": "_Ott_1080p_Avc_Aac_9x16_qvbr",
+  "Settings": {
+    "OutputGroups": [
+      {
+        "Name": "File Group",
+        "Outputs": [
+          {
+            "Extension": "mp4",
+            "NameModifier": "_Mp4_Avc_Aac_9x16_1080x1920p_24Hz_6Mbps_qvbr",
+            "Preset": "_Mp4_Avc_Aac_9x16_1080x1920p_24Hz_6Mbps_qvbr"
+          },
+          {
+            "Extension": "mp4",
+            "NameModifier": "_Mp4_Avc_Aac_9x16_720x1280p_24Hz_4.5Mbps_qvbr",
+            "Preset": "_Mp4_Avc_Aac_9x16_720x1280p_24Hz_4.5Mbps_qvbr"
+          }
+        ],
+        "OutputGroupSettings": {
+          "Type": "FILE_GROUP_SETTINGS",
+          "FileGroupSettings": {}
+        }
+      },
+      {
+        "Name": "Apple HLS",
+        "Outputs": [
+          {
+            "Preset": "_Ott_Hls_Ts_Avc_Aac_9x16_270x480p_15Hz_0.4Mbps_qvbr",
+            "NameModifier": "_Ott_Hls_Ts_Avc_Aac_9x16_270x480p_15Hz_0.4Mbps_qvbr"
+          },
+          {
+            "Preset": "_Ott_Hls_Ts_Avc_Aac_9x16_360x640p_30Hz_0.6Mbps_qvbr",
+            "NameModifier": "_Ott_Hls_Ts_Avc_Aac_9x16_360x640p_30Hz_0.6Mbps_qvbr"
+          },
+          {
+            "Preset": "_Ott_Hls_Ts_Avc_Aac_9x16_360x640p_30Hz_1.2Mbps_qvbr",
+            "NameModifier": "_Ott_Hls_Ts_Avc_Aac_9x16_360x640p_30Hz_1.2Mbps_qvbr"
+          },
+          {
+            "Preset": "_Ott_Hls_Ts_Avc_Aac_9x16_540x960p_30Hz_3.5Mbps_qvbr",
+            "NameModifier": "_Ott_Hls_Ts_Avc_Aac_9x16_540x960p_30Hz_3.5Mbps_qvbr"
+          },
+          {
+            "Preset": "_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_3.5Mbps_qvbr",
+            "NameModifier": "_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_3.5Mbps_qvbr"
+          },
+          {
+            "Preset": "_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_5.0Mbps_qvbr",
+            "NameModifier": "_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_5.0Mbps_qvbr"
+          },
+          {
+            "Preset": "_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_6.5Mbps_qvbr",
+            "NameModifier": "_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_6.5Mbps_qvbr"
+          },
+          {
+            "Preset": "_Ott_Hls_Ts_Avc_Aac_9x16_1080x1920p_30Hz_8.5Mbps_qvbr",
+            "NameModifier": "_Ott_Hls_Ts_Avc_Aac_9x16_1080x1920p_30Hz_8.5Mbps_qvbr"
+          }
+        ],
+        "OutputGroupSettings": {
+          "Type": "HLS_GROUP_SETTINGS",
+          "HlsGroupSettings": {
+            "ManifestDurationFormat": "INTEGER",
+            "SegmentLength": 3,
+            "TimedMetadataId3Period": 10,
+            "CaptionLanguageSetting": "OMIT",
+            "TimedMetadataId3Frame": "PRIV",
+            "CodecSpecification": "RFC_4281",
+            "OutputSelection": "MANIFESTS_AND_SEGMENTS",
+            "ProgramDateTimePeriod": 600,
+            "MinSegmentLength": 0,
+            "DirectoryStructure": "SINGLE_DIRECTORY",
+            "ProgramDateTime": "EXCLUDE",
+            "SegmentControl": "SEGMENTED_FILES",
+            "ManifestCompression": "NONE",
+            "ClientCache": "ENABLED",
+            "StreamInfResolution": "INCLUDE"
+          }
+        }
+      },
+      {
+        "Name": "DASH ISO",
+        "Outputs": [
+          {
+            "NameModifier": "_Ott_Dash_Mp4_Avc_9x16_270x480p_15Hz_0.4Mbps_qvbr",
+            "Preset": "_Ott_Dash_Mp4_Avc_9x16_270x480p_15Hz_0.4Mbps_qvbr"
+          },
+          {
+            "NameModifier": "_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_0.6Mbps_qvbr",
+            "Preset": "_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_0.6Mbps_qvbr"
+          },
+          {
+            "NameModifier": "_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_1.2Mbps_qvbr",
+            "Preset": "_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_1.2Mbps_qvbr"
+          },
+          {
+            "NameModifier": "_Ott_Dash_Mp4_Avc_9x16_960x540p_30Hz_3.5Mbps_qvbr",
+            "Preset": "_Ott_Dash_Mp4_Avc_9x16_540x960p_30Hz_3.5Mbps_qvbr"
+          },
+          {
+            "NameModifier": "_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_3.5Mbps_qvbr",
+            "Preset": "_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_3.5Mbps_qvbr"
+          },
+          {
+            "NameModifier": "_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_5.0Mbps_qvbr",
+            "Preset": "_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_5.0Mbps_qvbr"
+          },
+          {
+            "NameModifier": "_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_6.5Mbps_qvbr",
+            "Preset": "_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_6.5Mbps_qvbr"
+          },
+          {
+            "NameModifier": "_Ott_Dash_Mp4_Avc_9x16_1080x1920p_30Hz_8.5Mbps_qvbr",
+            "Preset": "_Ott_Dash_Mp4_Avc_9x16_1080x1920p_30Hz_8.5Mbps_qvbr"
+          },
+          {
+            "Preset": "System-Ott_Dash_Mp4_Aac_He_96Kbps",
+            "NameModifier": "_Ott_Dash_Mp4_Aac_He_96Kbps"
+          }
+        ],
+        "OutputGroupSettings": {
+          "Type": "DASH_ISO_GROUP_SETTINGS",
+          "DashIsoGroupSettings": {
+            "SegmentLength": 30,
+            "FragmentLength": 3,
+            "SegmentControl": "SEGMENTED_FILES",
+            "HbbtvCompliance": "NONE"
+          }
+        }
+      }
+    ],
+    "AdAvailOffset": 0
+  },
+  "StatusUpdateInterval": "SECONDS_60"
+}

--- a/source/custom-resource/lib/mediaconvert/templates/2160p_avc_aac_9x16_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/templates/2160p_avc_aac_9x16_qvbr.json
@@ -1,0 +1,133 @@
+{
+	"Category": "VOD",
+	"Description": "video on demand on aws",
+	"Name": "_Ott_2160p_Avc_Aac_9x16_qvbr",
+	"Settings": {
+		"AdAvailOffset": 0,
+		"OutputGroups": [{
+				"Name": "File Group",
+				"OutputGroupSettings": {
+					"Type": "FILE_GROUP_SETTINGS",
+					"FileGroupSettings": {}
+				},
+				"Outputs": [
+					{
+						"Preset": "_Mp4_Avc_Aac_9x16_1080x1920p_24Hz_6Mbps_qvbr",
+						"Extension": "mp4",
+						"NameModifier": "_Mp4_Avc_Aac_9x16_1080x1920p_24Hz_6Mbps_qvbr"
+					},
+					{
+						"Preset": "_Mp4_Avc_Aac_9x16_720x1280p_24Hz_4.5Mbps_qvbr",
+						"Extension": "mp4",
+						"NameModifier": "_Mp4_Avc_Aac_9x16_720x1280p_24Hz_4.5Mbps_qvbr"
+					}
+				]
+			},
+			{
+				"Name": "Apple HLS",
+				"Outputs": [{
+								"Preset": "_Ott_Hls_Ts_Avc_Aac_9x16_270x480p_15Hz_0.4Mbps_qvbr",
+								"NameModifier": "_Ott_Hls_Ts_Avc_Aac_9x16_270x480p_15Hz_0.4Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Hls_Ts_Avc_Aac_9x16_360x640p_30Hz_0.6Mbps_qvbr",
+								"NameModifier": "_Ott_Hls_Ts_Avc_Aac_9x16_360x640p_30Hz_0.6Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Hls_Ts_Avc_Aac_9x16_360x640p_30Hz_1.2Mbps_qvbr",
+								"NameModifier": "_Ott_Hls_Ts_Avc_Aac_9x16_360x640p_30Hz_1.2Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Hls_Ts_Avc_Aac_9x16_540x960p_30Hz_3.5Mbps_qvbr",
+								"NameModifier": "_Ott_Hls_Ts_Avc_Aac_9x16_540x960p_30Hz_3.5Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_3.5Mbps_qvbr",
+								"NameModifier": "_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_3.5Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_5.0Mbps_qvbr",
+								"NameModifier": "_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_5.0Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_6.5Mbps_qvbr",
+								"NameModifier": "_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_6.5Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Hls_Ts_Avc_Aac_9x16_1080x1920p_30Hz_8.5Mbps_qvbr",
+								"NameModifier": "_Ott_Hls_Ts_Avc_Aac_9x16_1080x1920p_30Hz_8.5Mbps_qvbr"
+							}
+						],
+						"OutputGroupSettings": {
+							"Type": "HLS_GROUP_SETTINGS",
+							"HlsGroupSettings": {
+								"ManifestDurationFormat": "INTEGER",
+								"SegmentLength": 3,
+								"TimedMetadataId3Period": 10,
+								"CaptionLanguageSetting": "OMIT",
+								"TimedMetadataId3Frame": "PRIV",
+								"CodecSpecification": "RFC_4281",
+								"OutputSelection": "MANIFESTS_AND_SEGMENTS",
+								"ProgramDateTimePeriod": 600,
+								"MinSegmentLength": 0,
+								"DirectoryStructure": "SINGLE_DIRECTORY",
+								"ProgramDateTime": "EXCLUDE",
+								"SegmentControl": "SEGMENTED_FILES",
+								"ManifestCompression": "NONE",
+								"ClientCache": "ENABLED",
+								"StreamInfResolution": "INCLUDE"
+							}
+						}
+					},
+					{
+						"Name": "DASH ISO",
+						"Outputs": [{
+								"Preset": "_Ott_Dash_Mp4_Avc_9x16_270x480p_15Hz_0.4Mbps_qvbr",
+								"NameModifier": "_Ott_Dash_Mp4_Avc_9x16_270x480p_15Hz_0.4Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_0.6Mbps_qvbr",
+								"NameModifier": "_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_0.6Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_1.2Mbps_qvbr",
+								"NameModifier": "_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_1.2Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Dash_Mp4_Avc_9x16_540x960p_30Hz_3.5Mbps_qvbr",
+								"NameModifier": "_Ott_Dash_Mp4_Avc_9x16_540x960p_30Hz_3.5Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_3.5Mbps_qvbr",
+								"NameModifier": "_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_3.5Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_5.0Mbps_qvbr",
+								"NameModifier": "_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_5.0Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_6.5Mbps_qvbr",
+								"NameModifier": "_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_6.5Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Dash_Mp4_Avc_9x16_1080x1920p_30Hz_8.5Mbps_qvbr",
+								"NameModifier": "_Ott_Dash_Mp4_Avc_9x16_1080x1920p_30Hz_8.5Mbps_qvbr"
+							},
+							{
+								"Preset": "System-Ott_Dash_Mp4_Aac_He_96Kbps",
+								"NameModifier": "_Ott_Dash_Mp4_Aac_He_96Kbps"
+							}
+						],
+						"OutputGroupSettings": {
+							"Type": "DASH_ISO_GROUP_SETTINGS",
+							"DashIsoGroupSettings": {
+								"SegmentLength": 30,
+								"FragmentLength": 3,
+								"SegmentControl": "SEGMENTED_FILES",
+								"HbbtvCompliance": "NONE"
+							}
+						}
+					}
+				]
+			}
+		}

--- a/source/custom-resource/lib/mediaconvert/templates/720p_avc_aac_9x16_qvbr.json
+++ b/source/custom-resource/lib/mediaconvert/templates/720p_avc_aac_9x16_qvbr.json
@@ -1,0 +1,120 @@
+{
+	"Category": "VOD",
+	"Description": "video on demand on aws",
+	"Name": "_Ott_720p_Avc_Aac_9x16_qvbr",
+	"Settings": {
+		"AdAvailOffset": 0,
+		"OutputGroups": [{
+				"Name": "File Group",
+				"OutputGroupSettings": {
+					"Type": "FILE_GROUP_SETTINGS",
+					"FileGroupSettings": {}
+				},
+				"Outputs": [
+					{
+						"Preset": "_Mp4_Avc_Aac_9x16_720x1280p_24Hz_4.5Mbps_qvbr",
+						"Extension": "mp4",
+						"NameModifier": "_Mp4_Avc_Aac_9x16_720x1280p_24Hz_4.5Mbps_qvbr"
+					}
+				]
+			},
+			{
+				"Name": "Apple HLS",
+				"Outputs": [{
+								"Preset": "_Ott_Hls_Ts_Avc_Aac_9x16_270x480p_15Hz_0.4Mbps_qvbr",
+								"NameModifier": "_Ott_Hls_Ts_Avc_Aac_9x16_270x480p_15Hz_0.4Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Hls_Ts_Avc_Aac_9x16_360x640p_30Hz_0.6Mbps_qvbr",
+								"NameModifier": "_Ott_Hls_Ts_Avc_Aac_9x16_360x640p_30Hz_0.6Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Hls_Ts_Avc_Aac_9x16_360x640p_30Hz_1.2Mbps_qvbr",
+								"NameModifier": "_Ott_Hls_Ts_Avc_Aac_9x16_360x640p_30Hz_1.2Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Hls_Ts_Avc_Aac_9x16_540x960p_30Hz_3.5Mbps_qvbr",
+								"NameModifier": "_Ott_Hls_Ts_Avc_Aac_9x16_540x960p_30Hz_3.5Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_3.5Mbps_qvbr",
+								"NameModifier": "_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_3.5Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_5.0Mbps_qvbr",
+								"NameModifier": "_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_5.0Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_6.5Mbps_qvbr",
+								"NameModifier": "_Ott_Hls_Ts_Avc_Aac_9x16_720x1280p_30Hz_6.5Mbps_qvbr"
+							}
+						],
+						"OutputGroupSettings": {
+							"Type": "HLS_GROUP_SETTINGS",
+							"HlsGroupSettings": {
+								"ManifestDurationFormat": "INTEGER",
+								"SegmentLength": 3,
+								"TimedMetadataId3Period": 10,
+								"CaptionLanguageSetting": "OMIT",
+								"TimedMetadataId3Frame": "PRIV",
+								"CodecSpecification": "RFC_4281",
+								"OutputSelection": "MANIFESTS_AND_SEGMENTS",
+								"ProgramDateTimePeriod": 600,
+								"MinSegmentLength": 0,
+								"DirectoryStructure": "SINGLE_DIRECTORY",
+								"ProgramDateTime": "EXCLUDE",
+								"SegmentControl": "SEGMENTED_FILES",
+								"ManifestCompression": "NONE",
+								"ClientCache": "ENABLED",
+								"StreamInfResolution": "INCLUDE"
+							}
+						}
+					},
+					{
+						"Name": "DASH ISO",
+						"Outputs": [{
+								"Preset": "_Ott_Dash_Mp4_Avc_9x16_270x480p_15Hz_0.4Mbps_qvbr",
+								"NameModifier": "_Ott_Dash_Mp4_Avc_9x16_270x480p_15Hz_0.4Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_0.6Mbps_qvbr",
+								"NameModifier": "_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_0.6Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_1.2Mbps_qvbr",
+								"NameModifier": "_Ott_Dash_Mp4_Avc_9x16_360x640p_30Hz_1.2Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Dash_Mp4_Avc_9x16_540x960p_30Hz_3.5Mbps_qvbr",
+								"NameModifier": "_Ott_Dash_Mp4_Avc_9x16_540x960p_30Hz_3.5Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_3.5Mbps_qvbr",
+								"NameModifier": "_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_3.5Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_5.0Mbps_qvbr",
+								"NameModifier": "_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_5.0Mbps_qvbr"
+							},
+							{
+								"Preset": "_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_6.5Mbps_qvbr",
+								"NameModifier": "_Ott_Dash_Mp4_Avc_9x16_720x1280p_30Hz_6.5Mbps_qvbr"
+							},
+							{
+								"Preset": "System-Ott_Dash_Mp4_Aac_He_96Kbps",
+								"NameModifier": "_Ott_Dash_Mp4_Aac_He_96Kbps"
+							}
+						],
+						"OutputGroupSettings": {
+							"Type": "DASH_ISO_GROUP_SETTINGS",
+							"DashIsoGroupSettings": {
+								"SegmentLength": 30,
+								"FragmentLength": 3,
+								"SegmentControl": "SEGMENTED_FILES",
+								"HbbtvCompliance": "NONE"
+							}
+						}
+					}
+				]
+			}
+		}

--- a/source/encode/index.js
+++ b/source/encode/index.js
@@ -52,7 +52,8 @@ exports.handler = async (event) => {
             }
           },
           "VideoSelector": {
-            "ColorSpace": "FOLLOW"
+            "ColorSpace": "FOLLOW",
+            "Rotate": "AUTO"
           },
           "FilterEnable": "AUTO",
           "PsiControl": "USE_PSI",

--- a/source/input-validate/index.js
+++ b/source/input-validate/index.js
@@ -40,7 +40,10 @@ exports.handler = async (event) => {
       archiveSource: JSON.parse(process.env.ArchiveSource),
       jobTemplate_2160p: process.env.MediaConvert_Template_2160p,
       jobTemplate_1080p: process.env.MediaConvert_Template_1080p,
-      jobTemplate_720p: process.env.MediaConvert_Template_720p
+      jobTemplate_720p: process.env.MediaConvert_Template_720p,
+      jobTemplate_2160p_portrait: process.env.MediaConvert_Template_2160p_Portrait,
+      jobTemplate_1080p_portrait: process.env.MediaConvert_Template_1080p_Portrait,
+      jobTemplate_720p_portrait: process.env.MediaConvert_Template_720p_Portrait
     };
 
     switch(event.workflowTrigger) {

--- a/source/nodejs/package.json
+++ b/source/nodejs/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "nodejs",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "aws-sdk": "^2.465.0"
+  }
+}

--- a/source/profiler/index.js
+++ b/source/profiler/index.js
@@ -49,14 +49,15 @@ exports.handler = async (event) => {
     }
 
     event.isPortrait = event.srcHeight > event.srcWidth;
+    event.lesserDimension = event.isPortrait ? event.srcWidth : event.srcHeight;
 
-    //Determine Encoding profile by matching the src Height to the nearest profile.
+    //Determine Encoding profile by matching the src to the nearest profile.
     const profiles = [2160, 1080, 720];
     let lastProfile;
     let encodeProfile;
 
     profiles.some(function(p) {
-      let profile = Math.abs(event.srcHeight - p);
+      let profile = Math.abs(event.lesserDimension - p);
       if (profile > lastProfile) {
         return true;
       }

--- a/source/profiler/index.js
+++ b/source/profiler/index.js
@@ -49,7 +49,7 @@ exports.handler = async (event) => {
     }
 
     //Determine Encoding profile by matching the src Height to the nearest profile.
-    const profiles = [2160, 1080,720];
+    const profiles = [2160, 1080, 720];
     let lastProfile;
     let encodeProfile;
 
@@ -78,22 +78,16 @@ exports.handler = async (event) => {
     // solution defaults
     if (!event.jobTemplate) {
       // Match the jobTemplate to the encoding Profile.
-      let jobTemplates;
-      if (event.isRotated) {
-        jobTemplates = {
-          '2160': event.jobTemplate_2160p_portrait,
-          '1080': event.jobTemplate_1080p_portrait,
-          '720': event.jobTemplate_720p_portrait
-        };
-      } else {
-        jobTemplates = {
-          '2160': event.jobTemplate_2160p,
-          '1080': event.jobTemplate_1080p,
-          '720': event.jobTemplate_720p
-        };
-      }
+      const jobTemplates = {
+        '2160': event.jobTemplate_2160p,
+        '1080': event.jobTemplate_1080p,
+        '720': event.jobTemplate_720p,
+        '2160p': event.jobTemplate_2160p_portrait,
+        '1080p': event.jobTemplate_1080p_portrait,
+        '720p': event.jobTemplate_720p_portrait
+      };
 
-      event.jobTemplate = jobTemplates[encodeProfile];
+      event.jobTemplate = jobTemplates[encodeProfile+(event.isRotated ? 'p' : '')];
       console.log('Encoding jobTemplates:: ', event.jobTemplate);
     }
   }

--- a/source/profiler/index.js
+++ b/source/profiler/index.js
@@ -48,6 +48,8 @@ exports.handler = async (event) => {
       event.srcWidth = mediaInfo.video[0].width;
     }
 
+    event.isPortrait = event.srcHeight > event.srcWidth;
+
     //Determine Encoding profile by matching the src Height to the nearest profile.
     const profiles = [2160, 1080, 720];
     let lastProfile;
@@ -87,7 +89,7 @@ exports.handler = async (event) => {
         '720p': event.jobTemplate_720p_portrait
       };
 
-      event.jobTemplate = jobTemplates[encodeProfile+(event.isRotated ? 'p' : '')];
+      event.jobTemplate = jobTemplates[encodeProfile+(event.isPortrait ? 'p' : '')];
       console.log('Encoding jobTemplates:: ', event.jobTemplate);
     }
   }

--- a/source/profiler/index.js
+++ b/source/profiler/index.js
@@ -38,8 +38,15 @@ exports.handler = async (event) => {
       event[key] = data.Item[key];
     });
     let mediaInfo = JSON.parse(event.srcMediainfo);
-    event.srcHeight = mediaInfo.video[0].height;
-    event.srcWidth = mediaInfo.video[0].width;
+    event.rotation = mediaInfo.video[0].rotation;
+    event.isRotated = (event.rotation !== 0 && event.rotation !== 180);
+    if (event.isRotated) {
+      event.srcHeight = mediaInfo.video[0].width;
+      event.srcWidth = mediaInfo.video[0].height;
+    } else {
+      event.srcHeight = mediaInfo.video[0].height;
+      event.srcWidth = mediaInfo.video[0].width;
+    }
 
     //Determine Encoding profile by matching the src Height to the nearest profile.
     const profiles = [2160, 1080,720];
@@ -71,11 +78,20 @@ exports.handler = async (event) => {
     // solution defaults
     if (!event.jobTemplate) {
       // Match the jobTemplate to the encoding Profile.
-      const jobTemplates = {
-        '2160': event.jobTemplate_2160p,
-        '1080': event.jobTemplate_1080p,
-        '720': event.jobTemplate_720p
-      };
+      let jobTemplates;
+      if (event.isRotated) {
+        jobTemplates = {
+          '2160': event.jobTemplate_2160p_portrait,
+          '1080': event.jobTemplate_1080p_portrait,
+          '720': event.jobTemplate_720p_portrait
+        };
+      } else {
+        jobTemplates = {
+          '2160': event.jobTemplate_2160p,
+          '1080': event.jobTemplate_1080p,
+          '720': event.jobTemplate_720p
+        };
+      }
 
       event.jobTemplate = jobTemplates[encodeProfile];
       console.log('Encoding jobTemplates:: ', event.jobTemplate);

--- a/source/sns-notification/index.js
+++ b/source/sns-notification/index.js
@@ -35,6 +35,9 @@ exports.handler = async (event) => {
 			delete msg.jobTemplate_2160p;
 			delete msg.jobTemplate_1080p;
 			delete msg.jobTemplate_720p;
+			delete msg.jobTemplate_2160p_portrait;
+			delete msg.jobTemplate_1080p_portrait;
+			delete msg.jobTemplate_720p_portrait;
 			delete msg.encodingJob;
 			delete msg.encodingOutput;
 		} else if (event.workflowStatus === 'Ingest') {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/video-on-demand-on-aws/issues/28

*Description of changes:*
- Updated README
- Added portrait templates for QVBR enabled workflow
- Added new layer to use the latest version of the `aws-sdk` in the `encode` lambda function
- Updated `encode` lambda function to use the `Rotate` parameter
- Updated `profiler` lambda function to detect the presence of `rotate` metadata and swap dimensions for profile selection
- Update `profiler` lambda function to pick the correct profile based on the appropriate dimension based on portrait vs. landscape

**Testing**
- Test each orientation from iOS - PASS
- Test each orientation from Android - IN PROGRESS

**NOTE: this has not been fully tested yet. I have had successful tests using portrait videos that were actually landscape but had the rotation meta data. Looking for help to fully test.**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
