### PR TITLE
Fix m4v typo in ingestion filter

### DIFF
--- a/source/custom-resource/lib/s3/index.js
+++ b/source/custom-resource/lib/s3/index.js
@@ -59,7 +59,7 @@ let PutNotification = async (config) => {
 									Key: {
 										FilterRules: [{
 											Name: 'suffix',
-											Value: '.mv4'
+											Value: '.m4v'
 										}]
 									}
 								}


### PR DESCRIPTION
*Description of changes:*

The README states that `m4v` files should be supported, but when I deployed this stack and uploaded an m4v file to my source bucket, nothing happened.

I believe the problem is caused by this typo in an ingestion lambda filter.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
