### PR TITLE
feat: add SnsTopic to the list of outputs

### DIFF
--- a/deployment/video-on-demand-on-aws.yaml
+++ b/deployment/video-on-demand-on-aws.yaml
@@ -1439,3 +1439,9 @@ Outputs:
     Value: !GetAtt Uuid.UUID
     Export:
       Name: !Join [":", [!Ref "AWS::StackName", UUID]]
+
+  SnsTopic:
+    Description: SNS Notification Topic
+    Value: !Ref SnsTopic
+    Export:
+      Name: !Join [":", [!Ref "AWS::StackName", SnsTopic]]


### PR DESCRIPTION
*Description of changes:* Since it may be useful to create a Lambda function to update an internal database with the current status or errors associated with this processing pipeline, it would be nice to have the SNS Topic ARN exported so I can use it as a nested stack.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
