### PR TITLE
fix: fix output-validate for non-root file paths

### DIFF
--- a/source/output-validate/index.js
+++ b/source/output-validate/index.js
@@ -15,7 +15,7 @@ const AWS = require('aws-sdk');
 const error = require('./lib/error.js');
 const moment = require('moment');
 
-const buildUrl = (originalValue) => originalValue.slice(5).split('/').splice(1, 3).join('/');
+const buildUrl = (originalValue) => originalValue.slice(5).split('/').splice(1).join('/');
 
 exports.handler = async (event) => {
     console.log(`REQUEST:: ${JSON.stringify(event, null, 2)}`);

--- a/source/output-validate/lib/index.spec.js
+++ b/source/output-validate/lib/index.spec.js
@@ -71,6 +71,14 @@ describe('#OUTPUT VALIDATE::', () => {
         expect(response.mp4Urls[0]).to.equal('https://cloudfront/12345/mp4/dude_3.0Mbps.mp4');
     });
 
+    it('should return "SUCCESS" on parsing outputs that are not on root path of bucket', async () => {
+        AWS.mock('DynamoDB.DocumentClient', 'get', Promise.resolve(data));
+
+        let response = await lambda.handler(_events.notRoot);
+        expect(response.mp4Outputs[0]).to.equal('s3://vod4-destination-fr0ao9hz7tbo/folder1/folder2/12345/mp4/dude_3.0Mbps.mp4');
+        expect(response.mp4Urls[0]).to.equal('https://cloudfront/folder1/folder2/12345/mp4/dude_3.0Mbps.mp4');
+    });
+
     it('should return "DB ERROR" when db get fails', async () => {
         AWS.mock('DynamoDB.DocumentClient', 'get', Promise.reject('DB ERROR'));
         AWS.mock('Lambda', 'invoke', Promise.resolve());

--- a/source/output-validate/lib/test-events.js
+++ b/source/output-validate/lib/test-events.js
@@ -94,8 +94,48 @@ const Mp4 = {
     }
 };
 
+const NotRoot = {
+    version: '0',
+    id: '371bc689-58cf-71f2-07f7-012b4fa59b79',
+    'detail-type': 'MediaConvert Job State Change',
+    source: 'aws.mediaconvert',
+    account: '111',
+    time: '2018-10-17T14:46:06Z',
+    region: 'us-east-1',
+    resources: [
+        'arn:aws:mediaconvert:us-east-1::jobs-htprrb'
+    ],
+    detail: {
+        queue: 'arn:aws:mediaconvert:us-east-1::queues/Default',
+        jobId: '-htprrb',
+        status: 'COMPLETE',
+        userMetadata: {
+            guid: '12345',
+            workflow: 'vod4'
+        },
+        outputGroupDetails: [
+            {
+                outputDetails: [
+                    {
+                        outputFilePaths: [
+                            's3://vod4-destination-fr0ao9hz7tbo/folder1/folder2/12345/mp4/dude_3.0Mbps.mp4'
+                        ],
+                        durationInMs: 13471,
+                        videoDetails: {
+                            widthInPx: 1280,
+                            heightInPx: 720
+                        }
+                    }
+                ],
+                type: 'FILE_GROUP'
+            }
+        ]
+    }
+};
+
 module.exports = {
     cmafMss: CmafMss,
     hlsDash: HlsDash,
-    mp4: Mp4
+    mp4: Mp4,
+    notRoot: NotRoot
 };


### PR DESCRIPTION
*Issue:* #61

*Description of changes:* Remove second parameter of slice call on buildUrl so we can get the entire file path on output-validate and add test case for non-root s3 objects


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
