### PR TITLE
fix: added aws.manifestfilter to query whitelist

### DIFF
--- a/source/custom-resource/lib/mediapackage/cloudfront.js
+++ b/source/custom-resource/lib/mediapackage/cloudfront.js
@@ -57,10 +57,10 @@ module.exports.addCustomOrigin = async (distributionId, domainName) => {
         PathPattern: 'out/*',
         TargetOriginId: originId,
         ForwardedValues: {
-            QueryString: false,
             Cookies: { Forward: 'none' },
             Headers: { Quantity: 0 },
-            QueryStringCacheKeys: { Quantity: 0 }
+            QueryString: true,
+            QueryStringCacheKeys: { Quantity: 1, Items: ['aws.manifestfilter'] }
         },
         TrustedSigners: { Enabled: false, Quantity: 0 },
         ViewerProtocolPolicy: 'redirect-to-https',


### PR DESCRIPTION
### *Issue*
If it is not cached by the query, the manifest filter is not available dynamically.

### *Description of changes:*
Added `aws.manifestfilter` query string to whitelist for using manifest filter of media package

---

Thank you for providing such a great solution 🙌