### PR TITLE
fix default settings overwriting template settings

### DIFF
--- a/source/encode/index.js
+++ b/source/encode/index.js
@@ -116,12 +116,8 @@ const getFrameGroup = (event, outputPath) => ({
     }]
 });
 
-const applySettingsIfNeeded = (isCustomTemplate, originalGroup, customGroup) => {
-    if (isCustomTemplate) {
-        return _.merge({}, originalGroup, customGroup);
-    }
-
-    return originalGroup;
+const mergeSettingsWithDefault = (originalGroup, customGroup) => {
+  return _.merge({}, originalGroup, customGroup);
 };
 
 exports.handler = async (event) => {
@@ -216,7 +212,7 @@ exports.handler = async (event) => {
             if (found) {
                 console.log(`${group.Name} found in Job Template`);
 
-                const outputGroup = applySettingsIfNeeded(event.isCustomTemplate, defaultGroup, group);
+                const outputGroup = mergeSettingsWithDefault(event.isCustomTemplate, defaultGroup, group);
                 job.Settings.OutputGroups.push(outputGroup);
             }
         });


### PR DESCRIPTION
*Description of changes:*
It appears the hard-coded default settings overwrite the templates created in MediaConvert.  For example, specifying a MediaConvert CMAF template with segment length of 5 seconds gets overwritten by the CMAF default of 30 seconds.

It appears code was added to handle the case of custom template settings, however, this should apply to all templates specified in MediaConvert.  MediaConvert template settings should take precedence over hard-coded settings in the `encode` lambda.  By removing the conditional, this has the desired effect for my use-case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
