### PR TITLE
Adding configuration to use S3 Sig V4 for presigned URLs

### DIFF
--- a/source/mediainfo/lambda_function.py
+++ b/source/mediainfo/lambda_function.py
@@ -16,6 +16,7 @@ import json
 import os
 import re
 import subprocess
+from botocore.config import Config
 
 def parse_number(num):
     if num is None:
@@ -98,9 +99,17 @@ def parse_text_attributes(track):
     return compact(attributes)
 
 def get_signed_url(bucket, obj):
+
     SIGNED_URL_EXPIRATION = 60 * 60 * 2
     AWS_REGION = os.environ['AWS_REGION']
-    s3_client = boto3.client('s3', endpoint_url=f'https://s3.{AWS_REGION}.amazonaws.com', region_name=AWS_REGION)
+    boto_config = Config(
+        region_name=AWS_REGION,
+        s3={
+            'addressing_style': 'virtual',
+            'signature_version': 's3v4'
+        }
+    )
+    s3_client = boto3.client('s3', config=boto_config)
 
     return s3_client.generate_presigned_url(
         'get_object',


### PR DESCRIPTION
Added configuration values, signature_version and addressing_style to ensure SigV4 is used instead
of SigV2 which is an older and less secure way to access S3 with presigned URLs

*Issue #, if available:*
#110 

*Description of changes:*
Adding a config object to specify the use of s3v4 signature version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
